### PR TITLE
fix: colormap2 spectrogram rendering + data locator component selection

### DIFF
--- a/src/data-locator.cpp
+++ b/src/data-locator.cpp
@@ -184,12 +184,13 @@ bool QCPDataLocator::locateMultiGraph(const QPointF& pixelPos)
         return false;
 
     int index = map["dataIndex"].toInt();
+    int component = map.value("componentIndex", 0).toInt();
     auto* src = mg->dataSource();
     if (!src || index < 0 || index >= mg->dataCount())
         return false;
 
     mKey = mg->dataMainKey(index);
-    mValue = mg->dataMainValue(index);
+    mValue = src->valueAt(component, index);
     mDataIndex = index;
     mHitPlottable = mPlottable;
     mValid = true;

--- a/src/data-locator.cpp
+++ b/src/data-locator.cpp
@@ -186,7 +186,8 @@ bool QCPDataLocator::locateMultiGraph(const QPointF& pixelPos)
     int index = map["dataIndex"].toInt();
     int component = map.value("componentIndex", 0).toInt();
     auto* src = mg->dataSource();
-    if (!src || index < 0 || index >= mg->dataCount())
+    if (!src || index < 0 || index >= mg->dataCount()
+        || component < 0 || component >= src->columnCount())
         return false;
 
     mKey = mg->dataMainKey(index);

--- a/src/datasource/resample.cpp
+++ b/src/datasource/resample.cpp
@@ -120,25 +120,39 @@ QCPColorMapData* resample(
     }
 
     // Precompute Y bin ranges: each source Y-row fills bins within half its
-    // local spacing (bounded fill, no bleed beyond data extent)
+    // local spacing (bounded fill, no bleed beyond data extent).
+    // For log-scaled Y axes, boundaries are geometric means of neighbors
+    // so that channels tile correctly in log space.
     struct BinRange { int lo, hi; };
     std::vector<BinRange> yBinRanges(ys);
     for (int yj = 0; yj < ys; ++yj)
     {
         double yVal = src.yAt(xBegin, yj);
-        double halfSpacing;
+        double yLo, yHi;
         if (ys == 1)
-            halfSpacing = 0;
-        else if (yj == 0)
-            halfSpacing = (src.yAt(xBegin, 1) - yVal) * 0.5;
-        else if (yj == ys - 1)
-            halfSpacing = (yVal - src.yAt(xBegin, yj - 1)) * 0.5;
+        {
+            yLo = yHi = yVal;
+        }
+        else if (yLogScale && yVal > 0)
+        {
+            double prev = (yj > 0) ? src.yAt(xBegin, yj - 1) : 0;
+            double next = (yj < ys - 1) ? src.yAt(xBegin, yj + 1) : 0;
+            yLo = (yj > 0 && prev > 0) ? std::sqrt(prev * yVal) : yVal;
+            yHi = (yj < ys - 1 && next > 0) ? std::sqrt(yVal * next) : yVal;
+        }
         else
-            halfSpacing = std::min(yVal - src.yAt(xBegin, yj - 1),
-                                   src.yAt(xBegin, yj + 1) - yVal) * 0.5;
+        {
+            double halfBelow = (yj > 0) ? (yVal - src.yAt(xBegin, yj - 1)) * 0.5 : 0;
+            double halfAbove = (yj < ys - 1) ? (src.yAt(xBegin, yj + 1) - yVal) * 0.5 : 0;
+            if (yj == 0) halfBelow = halfAbove;
+            if (yj == ys - 1) halfAbove = halfBelow;
+            double halfSpacing = std::min(halfBelow, halfAbove);
+            yLo = yVal - halfSpacing;
+            yHi = yVal + halfSpacing;
+        }
 
-        yBinRanges[yj].lo = findBin(yVal - halfSpacing, yAxis);
-        yBinRanges[yj].hi = findBinFloor(yVal + halfSpacing, yAxis);
+        yBinRanges[yj].lo = findBin(yLo, yAxis);
+        yBinRanges[yj].hi = findBinFloor(yHi, yAxis);
     }
 
     for (int si = 0; si < srcCount; ++si)

--- a/src/plottables/plottable-colormap.cpp
+++ b/src/plottables/plottable-colormap.cpp
@@ -24,6 +24,7 @@
 ****************************************************************************/
 
 #include "plottable-colormap.h"
+#include <cmath>
 
 #include "../axis/axis.h"
 #include "../core.h"
@@ -420,10 +421,13 @@ void QCPColorMapData::recalculateDataBounds()
         const int dataCount = mValueSize * mKeySize;
         for (int i = 0; i < dataCount; ++i)
         {
-            if (mData[i] > maxHeight)
-                maxHeight = mData[i];
-            if (mData[i] < minHeight)
-                minHeight = mData[i];
+            const double v = mData[i];
+            if (std::isnan(v))
+                continue;
+            if (v > maxHeight)
+                maxHeight = v;
+            if (v < minHeight)
+                minHeight = v;
         }
         mDataBounds.lower = minHeight;
         mDataBounds.upper = maxHeight;

--- a/src/plottables/plottable-colormap.cpp
+++ b/src/plottables/plottable-colormap.cpp
@@ -429,8 +429,15 @@ void QCPColorMapData::recalculateDataBounds()
             if (v < minHeight)
                 minHeight = v;
         }
-        mDataBounds.lower = minHeight;
-        mDataBounds.upper = maxHeight;
+        if (minHeight <= maxHeight)
+        {
+            mDataBounds.lower = minHeight;
+            mDataBounds.upper = maxHeight;
+        }
+        else
+        {
+            mDataBounds = QCPRange(0, 0);
+        }
     }
 }
 

--- a/src/plottables/plottable-colormap2.cpp
+++ b/src/plottables/plottable-colormap2.cpp
@@ -101,10 +101,12 @@ void QCPColorMap2::setGradient(const QCPColorGradient& gradient)
     if (mGradient != gradient)
     {
         mGradient = gradient;
+        if (mGradient.nanHandling() == QCPColorGradient::nhNone)
+            mGradient.setNanHandling(QCPColorGradient::nhTransparent);
         mMapImageInvalidated = true;
         Q_EMIT gradientChanged(mGradient);
         if (mParentPlot)
-            mParentPlot->replot();
+            mParentPlot->replot(QCustomPlot::rpQueuedReplot);
     }
 }
 
@@ -114,6 +116,7 @@ void QCPColorMap2::setColorScale(QCPColorScale* colorScale)
     {
         disconnect(this, &QCPColorMap2::dataRangeChanged, mColorScale, &QCPColorScale::setDataRange);
         disconnect(this, &QCPColorMap2::gradientChanged, mColorScale, &QCPColorScale::setGradient);
+        disconnect(this, &QCPColorMap2::dataScaleTypeChanged, mColorScale, &QCPColorScale::setDataScaleType);
         disconnect(mColorScale, &QCPColorScale::dataRangeChanged, this, &QCPColorMap2::setDataRange);
         disconnect(mColorScale, &QCPColorScale::gradientChanged, this, &QCPColorMap2::setGradient);
         disconnect(mColorScale, &QCPColorScale::dataScaleTypeChanged, this, &QCPColorMap2::setDataScaleType);
@@ -122,10 +125,11 @@ void QCPColorMap2::setColorScale(QCPColorScale* colorScale)
     if (mColorScale)
     {
         setGradient(mColorScale->gradient());
-        setDataRange(mColorScale->dataRange());
         setDataScaleType(mColorScale->dataScaleType());
+        setDataRange(mColorScale->dataRange());
         connect(this, &QCPColorMap2::dataRangeChanged, mColorScale, &QCPColorScale::setDataRange);
         connect(this, &QCPColorMap2::gradientChanged, mColorScale, &QCPColorScale::setGradient);
+        connect(this, &QCPColorMap2::dataScaleTypeChanged, mColorScale, &QCPColorScale::setDataScaleType);
         connect(mColorScale, &QCPColorScale::dataRangeChanged, this, &QCPColorMap2::setDataRange);
         connect(mColorScale, &QCPColorScale::gradientChanged, this, &QCPColorMap2::setGradient);
         connect(mColorScale, &QCPColorScale::dataScaleTypeChanged, this, &QCPColorMap2::setDataScaleType);
@@ -134,13 +138,17 @@ void QCPColorMap2::setColorScale(QCPColorScale* colorScale)
 
 void QCPColorMap2::setDataRange(const QCPRange& range)
 {
-    if (mDataRange.lower != range.lower || mDataRange.upper != range.upper)
+    if (!QCPRange::validRange(range))
+        return;
+    QCPRange newRange = (mDataScaleType == QCPAxis::stLogarithmic)
+        ? range.sanitizedForLogScale() : range.sanitizedForLinScale();
+    if (mDataRange.lower != newRange.lower || mDataRange.upper != newRange.upper)
     {
-        mDataRange = range;
+        mDataRange = newRange;
         mMapImageInvalidated = true;
         Q_EMIT dataRangeChanged(mDataRange);
         if (mParentPlot)
-            mParentPlot->replot();
+            mParentPlot->replot(QCustomPlot::rpQueuedReplot);
     }
 }
 
@@ -150,8 +158,18 @@ void QCPColorMap2::setDataScaleType(QCPAxis::ScaleType type)
     {
         mDataScaleType = type;
         mMapImageInvalidated = true;
+        if (type == QCPAxis::stLogarithmic && QCPRange::validRange(mDataRange))
+        {
+            QCPRange sanitized = mDataRange.sanitizedForLogScale();
+            if (mDataRange.lower != sanitized.lower || mDataRange.upper != sanitized.upper)
+            {
+                mDataRange = sanitized;
+                Q_EMIT dataRangeChanged(mDataRange);
+            }
+        }
+        Q_EMIT dataScaleTypeChanged(mDataScaleType);
         if (mParentPlot)
-            mParentPlot->replot();
+            mParentPlot->replot(QCustomPlot::rpQueuedReplot);
     }
 }
 

--- a/src/plottables/plottable-colormap2.cpp
+++ b/src/plottables/plottable-colormap2.cpp
@@ -15,6 +15,7 @@ QCPColorMap2::QCPColorMap2(QCPAxis* keyAxis, QCPAxis* valueAxis)
     , mPipeline(parentPlot() ? parentPlot()->pipelineScheduler() : nullptr, this)
 {
     mGradient.loadPreset(QCPColorGradient::gpCold);
+    mGradient.setNanHandling(QCPColorGradient::nhTransparent);
 
     mPipeline.setTransform(TransformKind::ViewportDependent,
         [&gapThreshold = mGapThreshold](
@@ -115,16 +116,19 @@ void QCPColorMap2::setColorScale(QCPColorScale* colorScale)
         disconnect(this, &QCPColorMap2::gradientChanged, mColorScale, &QCPColorScale::setGradient);
         disconnect(mColorScale, &QCPColorScale::dataRangeChanged, this, &QCPColorMap2::setDataRange);
         disconnect(mColorScale, &QCPColorScale::gradientChanged, this, &QCPColorMap2::setGradient);
+        disconnect(mColorScale, &QCPColorScale::dataScaleTypeChanged, this, &QCPColorMap2::setDataScaleType);
     }
     mColorScale = colorScale;
     if (mColorScale)
     {
         setGradient(mColorScale->gradient());
         setDataRange(mColorScale->dataRange());
+        setDataScaleType(mColorScale->dataScaleType());
         connect(this, &QCPColorMap2::dataRangeChanged, mColorScale, &QCPColorScale::setDataRange);
         connect(this, &QCPColorMap2::gradientChanged, mColorScale, &QCPColorScale::setGradient);
         connect(mColorScale, &QCPColorScale::dataRangeChanged, this, &QCPColorMap2::setDataRange);
         connect(mColorScale, &QCPColorScale::gradientChanged, this, &QCPColorMap2::setGradient);
+        connect(mColorScale, &QCPColorScale::dataScaleTypeChanged, this, &QCPColorMap2::setDataScaleType);
     }
 }
 
@@ -135,6 +139,17 @@ void QCPColorMap2::setDataRange(const QCPRange& range)
         mDataRange = range;
         mMapImageInvalidated = true;
         Q_EMIT dataRangeChanged(mDataRange);
+        if (mParentPlot)
+            mParentPlot->replot();
+    }
+}
+
+void QCPColorMap2::setDataScaleType(QCPAxis::ScaleType type)
+{
+    if (mDataScaleType != type)
+    {
+        mDataScaleType = type;
+        mMapImageInvalidated = true;
         if (mParentPlot)
             mParentPlot->replot();
     }
@@ -192,7 +207,8 @@ void QCPColorMap2::updateMapImage()
             rowData[x] = data->cell(x, y);
 
         QRgb* pixels = reinterpret_cast<QRgb*>(argbImage.scanLine(valueSize - 1 - y));
-        mGradient.colorize(rowData.data(), mDataRange, pixels, keySize);
+        mGradient.colorize(rowData.data(), mDataRange, pixels, keySize,
+                           1, mDataScaleType == QCPAxis::stLogarithmic);
     }
 
     mMapImage = argbImage.convertToFormat(QImage::Format_RGBA8888_Premultiplied);

--- a/src/plottables/plottable-colormap2.h
+++ b/src/plottables/plottable-colormap2.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "plottable.h"
+#include <axis/axis.h>
 #include <datasource/async-pipeline.h>
 #include <datasource/soa-datasource-2d.h>
 #include <colorgradient.h>
@@ -59,6 +60,8 @@ public:
     QCPColorGradient gradient() const { return mGradient; }
     QCPColorScale* colorScale() const { return mColorScale; }
     QCPRange dataRange() const { return mDataRange; }
+    QCPAxis::ScaleType dataScaleType() const { return mDataScaleType; }
+    void setDataScaleType(QCPAxis::ScaleType type);
 
     void setColorScale(QCPColorScale* colorScale);
     void rescaleDataRange(bool recalc = false);
@@ -91,6 +94,7 @@ private:
     QCPColorGradient mGradient;
     QCPColorScale* mColorScale = nullptr;
     QCPRange mDataRange;
+    QCPAxis::ScaleType mDataScaleType = QCPAxis::stLinear;
 
     QImage mMapImage;
     bool mMapImageInvalidated = true;

--- a/src/plottables/plottable-colormap2.h
+++ b/src/plottables/plottable-colormap2.h
@@ -82,6 +82,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void dataRangeChanged(const QCPRange& newRange);
     void gradientChanged(const QCPColorGradient& newGradient);
+    void dataScaleTypeChanged(QCPAxis::ScaleType newType);
 
 protected:
     void draw(QCPPainter* painter) override;

--- a/tests/auto/test-data-locator/test-data-locator.cpp
+++ b/tests/auto/test-data-locator/test-data-locator.cpp
@@ -1,5 +1,6 @@
 #include "test-data-locator.h"
 #include "data-locator.h"
+#include <plottables/plottable-multigraph.h>
 
 void TestDataLocator::init()
 {
@@ -124,4 +125,34 @@ void TestDataLocator::locateWithNullPlottable()
 
     QVERIFY(!found);
     QVERIFY(!locator.isValid());
+}
+
+void TestDataLocator::locateOnMultiGraphSelectsClosestComponent()
+{
+    // Bug: locateMultiGraph always returned component 0's value regardless
+    // of which component was closest to the cursor position.
+    auto* mg = new QCPMultiGraph(mPlot->xAxis, mPlot->yAxis);
+    mPlot->xAxis->setRange(0, 4);
+    mPlot->yAxis->setRange(-50, 50);
+
+    // Component 0 at y=10, component 1 at y=-30
+    std::vector<double> keys = {1.0, 2.0, 3.0};
+    std::vector<std::vector<double>> values = {
+        {10.0, 10.0, 10.0},   // component 0
+        {-30.0, -30.0, -30.0} // component 1
+    };
+    mg->setData(std::move(keys), std::move(values));
+    mPlot->replot();
+
+    // Locate near component 1 (y=-30) at x=2
+    QPointF pixelNearComp1 = mg->coordsToPixels(2.0, -30.0);
+
+    QCPDataLocator locator;
+    locator.setPlottable(mg);
+    bool found = locator.locate(pixelNearComp1);
+
+    QVERIFY(found);
+    QVERIFY(locator.isValid());
+    // Must return component 1's value (-30), not component 0's (10)
+    QCOMPARE(locator.value(), -30.0);
 }

--- a/tests/auto/test-data-locator/test-data-locator.h
+++ b/tests/auto/test-data-locator/test-data-locator.h
@@ -14,6 +14,7 @@ private slots:
     void locateOnColorMap();
     void locateOnEmptyPlottable();
     void locateWithNullPlottable();
+    void locateOnMultiGraphSelectsClosestComponent();
 
 private:
     QCustomPlot* mPlot;

--- a/tests/auto/test-datasource2d/test-datasource2d.cpp
+++ b/tests/auto/test-datasource2d/test-datasource2d.cpp
@@ -437,6 +437,85 @@ void TestDataSource2D::resampleGapDetectedWithTwoVisibleColumns()
     delete r;
 }
 
+void TestDataSource2D::resampleLogYNoBinGaps()
+{
+    // Bug #1: With log-scaled Y and widely-spaced channels (e.g. energy spectrogram),
+    // arithmetic half-spacing left gaps between channels that showed as white lines.
+    // With the fix, geometric midpoints are used, so all output bins get data.
+    std::vector<double> x = {0.0, 1.0, 2.0};
+    std::vector<double> y = {1.0, 10.0, 100.0, 1000.0, 10000.0};
+    std::vector<double> z(15);
+    for (int i = 0; i < 15; ++i)
+        z[i] = static_cast<double>(i + 1);
+
+    QCPSoADataSource2D src(std::move(x), std::move(y), std::move(z));
+
+    auto* r = qcp::algo2d::resample(src, 0, 3,
+        QCPRange(0, 2), QCPRange(1, 10000), 3, 50, true, 1.5);
+    QVERIFY(r);
+
+    // Every output bin should have data — no NaN gaps between channels
+    int nanCount = 0;
+    for (int i = 0; i < r->keySize(); ++i)
+        for (int j = 0; j < r->valueSize(); ++j)
+            if (std::isnan(r->cell(i, j)))
+                ++nanCount;
+
+    QVERIFY2(nanCount == 0,
+        qPrintable(QString("Log-Y resample has %1 NaN bins out of %2 — channels have gaps")
+            .arg(nanCount).arg(r->keySize() * r->valueSize())));
+
+    delete r;
+}
+
+void TestDataSource2D::dataBoundsSkipsNaN()
+{
+    // Bug #4: recalculateDataBounds didn't skip NaN, leading to wrong Z range.
+    QCPColorMapData data(3, 2, QCPRange(0, 2), QCPRange(0, 1));
+    data.setCell(0, 0, 5.0);
+    data.setCell(1, 0, std::nan(""));
+    data.setCell(2, 0, 10.0);
+    data.setCell(0, 1, std::nan(""));
+    data.setCell(1, 1, 2.0);
+    data.setCell(2, 1, std::nan(""));
+
+    data.recalculateDataBounds();
+
+    QCOMPARE(data.dataBounds().lower, 2.0);
+    QCOMPARE(data.dataBounds().upper, 10.0);
+}
+
+void TestDataSource2D::colormap2NanHandling()
+{
+    // Bug #2: Default NaN handling was nhNone, causing UB when colorizing
+    // resampled data (which naturally contains NaN for empty bins).
+    // After fix, QCPColorMap2 sets nhTransparent by default.
+    auto* cm = new QCPColorMap2(mPlot->xAxis, mPlot->yAxis);
+    QCOMPARE(cm->gradient().nanHandling(), QCPColorGradient::nhTransparent);
+}
+
+void TestDataSource2D::colormap2DataScaleTypeSync()
+{
+    // Bug #3: colorize() was always called with logarithmic=false.
+    // Verify that dataScaleType propagates from QCPColorScale.
+    auto* cm = new QCPColorMap2(mPlot->xAxis, mPlot->yAxis);
+    auto* cs = new QCPColorScale(mPlot);
+    mPlot->plotLayout()->addElement(0, 1, cs);
+
+    QCOMPARE(cm->dataScaleType(), QCPAxis::stLinear);
+
+    cs->setDataScaleType(QCPAxis::stLogarithmic);
+    cm->setColorScale(cs);
+    QCOMPARE(cm->dataScaleType(), QCPAxis::stLogarithmic);
+
+    // Changing scale type on color scale propagates to colormap
+    cs->setDataScaleType(QCPAxis::stLinear);
+    QCOMPARE(cm->dataScaleType(), QCPAxis::stLinear);
+
+    cs->setDataScaleType(QCPAxis::stLogarithmic);
+    QCOMPARE(cm->dataScaleType(), QCPAxis::stLogarithmic);
+}
+
 void TestDataSource2D::colormap2Creation()
 {
     auto* cm = new QCPColorMap2(mPlot->xAxis, mPlot->yAxis);

--- a/tests/auto/test-datasource2d/test-datasource2d.cpp
+++ b/tests/auto/test-datasource2d/test-datasource2d.cpp
@@ -4,6 +4,7 @@
 #include <datasource/soa-datasource-2d.h>
 #include <datasource/resample.h>
 #include <QtTest/QtTest>
+#include <cmath>
 #include <span>
 
 void TestDataSource2D::init()
@@ -514,6 +515,13 @@ void TestDataSource2D::colormap2DataScaleTypeSync()
 
     cs->setDataScaleType(QCPAxis::stLogarithmic);
     QCOMPARE(cm->dataScaleType(), QCPAxis::stLogarithmic);
+
+    // Reverse direction: colormap -> color scale
+    cm->setDataScaleType(QCPAxis::stLinear);
+    QCOMPARE(cs->dataScaleType(), QCPAxis::stLinear);
+
+    cm->setDataScaleType(QCPAxis::stLogarithmic);
+    QCOMPARE(cs->dataScaleType(), QCPAxis::stLogarithmic);
 }
 
 void TestDataSource2D::colormap2Creation()

--- a/tests/auto/test-datasource2d/test-datasource2d.h
+++ b/tests/auto/test-datasource2d/test-datasource2d.h
@@ -35,6 +35,12 @@ private slots:
     void resampleGapDetectedWhenZoomedIn();
     void resampleGapDetectedWithTwoVisibleColumns();
 
+    // Bug fix regression tests
+    void resampleLogYNoBinGaps();
+    void dataBoundsSkipsNaN();
+    void colormap2NanHandling();
+    void colormap2DataScaleTypeSync();
+
     // QCPColorMap2 integration tests
     void colormap2Creation();
     void colormap2SetDataOwning();

--- a/tests/manual/gallery/main.cpp
+++ b/tests/manual/gallery/main.cpp
@@ -159,7 +159,6 @@ static QWidget* createColorMapTab()
     auto* cm = new QCPColorMap2(plot->xAxis, plot->yAxis);
     cm->setData(std::move(x), std::move(y), std::move(z));
     cm->setGapThreshold(3.0);
-    cm->rescaleDataRange(true);
 
     auto* scale = new QCPColorScale(plot);
     plot->plotLayout()->addElement(0, 1, scale);
@@ -168,13 +167,78 @@ static QWidget* createColorMapTab()
     QCPColorGradient gradient(QCPColorGradient::gpJet);
     gradient.setNanHandling(QCPColorGradient::nhTransparent);
     cm->setGradient(gradient);
+    cm->rescaleDataRange(true);
 
     plot->rescaleAxes();
     plot->replot();
     return wrapPlot(plot);
 }
 
-// ── Tab 4: MultiGraph ────────────────────────────────────────────────────────
+// ── Tab 4: ColorMap2 Log-Y + Log-Z + NaN + Gaps ─────────────────────────
+
+static QWidget* createColorMapLogTab()
+{
+    auto* plot = makePlot();
+
+    // Energy spectrogram: log-spaced Y channels, two data segments with a gap
+    const int nChannels = 32;
+    std::vector<double> y(nChannels);
+    for (int j = 0; j < nChannels; ++j)
+        y[j] = std::pow(10.0, 0.5 + j * 3.5 / (nChannels - 1)); // ~3 to ~31623
+
+    std::vector<double> x, z;
+    auto addSegment = [&](double t0, double t1, double dt) {
+        for (double t = t0; t <= t1; t += dt) {
+            x.push_back(t);
+            for (int j = 0; j < nChannels; ++j) {
+                double freq = y[j];
+                double logFreq = std::log10(freq);
+                // Two spectral peaks drifting in time, plus noise
+                double peak1 = 2.0 + 0.5 * std::sin(t * 0.3);
+                double peak2 = 3.5 + 0.3 * std::cos(t * 0.2);
+                double v = std::exp(-(logFreq - peak1) * (logFreq - peak1) / 0.15)
+                         + 0.6 * std::exp(-(logFreq - peak2) * (logFreq - peak2) / 0.08)
+                         + 0.02 * std::sin(logFreq * t);
+                // Sprinkle some NaN to simulate missing data
+                if (std::sin(t * 7.1 + j * 1.3) > 0.97)
+                    v = std::nan("");
+                z.push_back(v);
+            }
+        }
+    };
+
+    addSegment(0.0, 30.0, 0.5);   // segment 1
+    // gap: 30 to 50
+    addSegment(50.0, 100.0, 0.5);  // segment 2
+
+    auto* cm = new QCPColorMap2(plot->xAxis, plot->yAxis);
+    cm->setData(std::move(x), std::move(y), std::move(z));
+    cm->setGapThreshold(3.0);
+
+    // Log-Y axis
+    plot->yAxis->setScaleType(QCPAxis::stLogarithmic);
+    plot->yAxis->setTicker(QSharedPointer<QCPAxisTickerLog>::create());
+    plot->yAxis->setLabel("Energy (eV)");
+    plot->xAxis->setLabel("Time (s)");
+
+    // Color scale with log-Z
+    auto* scale = new QCPColorScale(plot);
+    plot->plotLayout()->addElement(0, 1, scale);
+    scale->setDataScaleType(QCPAxis::stLogarithmic);
+    scale->axis()->setTicker(QSharedPointer<QCPAxisTickerLog>::create());
+    cm->setColorScale(scale);
+
+    QCPColorGradient gradient(QCPColorGradient::gpJet);
+    gradient.setNanHandling(QCPColorGradient::nhTransparent);
+    cm->setGradient(gradient);
+    cm->rescaleDataRange(true);
+
+    plot->rescaleAxes();
+    plot->replot();
+    return wrapPlot(plot);
+}
+
+// ── Tab 5: MultiGraph ────────────────────────────────────────────────────────
 
 static QWidget* createMultiGraphTab()
 {
@@ -676,6 +740,7 @@ int main(int argc, char* argv[])
     tabs->addTab(createSpansTab(),       "Spans");
     tabs->addTab(createGraphTab(),       "Graph / Curve");
     tabs->addTab(createColorMapTab(),    "ColorMap2");
+    tabs->addTab(createColorMapLogTab(), "ColorMap2 Log/NaN/Gap");
     tabs->addTab(createMultiGraphTab(),  "MultiGraph");
     tabs->addTab(createWaterfallTab(),   "Waterfall");
     tabs->addTab(createItemsTab(),       "Items");

--- a/tests/manual/gallery/main.cpp
+++ b/tests/manual/gallery/main.cpp
@@ -3,6 +3,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QTimer>
+#include <cmath>
 #include <numbers>
 #include "../../../src/qcp.h"
 


### PR DESCRIPTION
## Summary

- **White horizontal lines on log-Y spectrograms**: Y bin boundaries in the resampler now use geometric midpoints for log-scaled axes, eliminating gaps between energy channels
- **Crash from NaN in colorize()**: QCPColorMap2 gradient defaults to `nhTransparent`, preventing UB from `qint64(NaN)` on empty resampled bins
- **Broken Z auto-scale appearance**: Added `dataScaleType` property to QCPColorMap2, passing the logarithmic flag to `colorize()` and syncing with `QCPColorScale::dataScaleTypeChanged`
- **Wrong Z range with NaN data**: `recalculateDataBounds()` now skips NaN values
- **MultiGraph tracer snaps to wrong component**: `locateMultiGraph()` reads `componentIndex` from `selectTest()` details instead of hardcoding component 0
- Gallery: new "ColorMap2 Log/NaN/Gap" tab, fix color scale ordering in existing ColorMap2 tab

## Test plan

- [x] 5 regression tests added (resampleLogYNoBinGaps, dataBoundsSkipsNaN, colormap2NanHandling, colormap2DataScaleTypeSync, locateOnMultiGraphSelectsClosestComponent)
- [x] Full test suite passes (255 tests, 0 failures)
- [x] Visual verification with gallery "ColorMap2 Log/NaN/Gap" tab
- [ ] Test in SciQLop with MMS energy spectrogram data

🤖 Generated with [Claude Code](https://claude.com/claude-code)