### PR TITLE
perf: fix zoom/pan lag on large datasets (hierarchical resampling)

### DIFF
--- a/src/axis/axis.cpp
+++ b/src/axis/axis.cpp
@@ -31,6 +31,7 @@
 #include "../painting/painter.h"
 #include "../plottables/plottable.h"
 #include "../plottables/plottable-graph.h"
+#include "../Profiling.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPGrid
@@ -1411,6 +1412,7 @@ void QCPAxis::scaleRange(double factor)
 */
 void QCPAxis::scaleRange(double factor, double center)
 {
+    PROFILE_HERE_N("QCPAxis::scaleRange");
     QCPRange oldRange = mRange;
     if (mScaleType == stLinear)
     {

--- a/src/datasource/algorithms.h
+++ b/src/datasource/algorithms.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "abstract-datasource.h"
 #include "axis/axis.h"
+#include "../Profiling.hpp"
 #include <algorithm>
 #include <cmath>
 #include <QtGlobal>
@@ -58,6 +59,47 @@ QCPRange keyRange(const KC& keys, bool& foundRange, QCP::SignDomain sd = QCP::sd
         foundRange = true;
     }
     return foundRange ? QCPRange(lower, upper) : QCPRange();
+}
+
+// O(1) key range for sorted data (sdBoth), O(log n) for sign-domain filtering.
+template <IndexableNumericRange KC>
+QCPRange keyRangeSorted(const KC& keys, bool& foundRange, QCP::SignDomain sd = QCP::sdBoth)
+{
+    foundRange = false;
+    const int sz = static_cast<int>(std::ranges::size(keys));
+    if (sz == 0) return {};
+
+    if (sd == QCP::sdBoth)
+    {
+        foundRange = true;
+        return QCPRange(static_cast<double>(keys[0]),
+                        static_cast<double>(keys[sz - 1]));
+    }
+
+    // For sdPositive/sdNegative, binary search for the boundary
+    if (sd == QCP::sdPositive)
+    {
+        auto it = std::upper_bound(std::ranges::begin(keys), std::ranges::end(keys),
+                                    0.0, [](double val, const auto& elem) {
+                                        return val < static_cast<double>(elem);
+                                    });
+        if (it == std::ranges::end(keys)) return {};
+        foundRange = true;
+        return QCPRange(static_cast<double>(*it),
+                        static_cast<double>(keys[sz - 1]));
+    }
+    else // sdNegative
+    {
+        auto it = std::lower_bound(std::ranges::begin(keys), std::ranges::end(keys),
+                                    0.0, [](const auto& elem, double val) {
+                                        return static_cast<double>(elem) < val;
+                                    });
+        if (it == std::ranges::begin(keys)) return {};
+        --it;
+        foundRange = true;
+        return QCPRange(static_cast<double>(keys[0]),
+                        static_cast<double>(*it));
+    }
 }
 
 template <IndexableNumericRange KC, IndexableNumericRange VC>
@@ -146,6 +188,7 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
                                     int /*pixelWidth*/,
                                     QCPAxis* keyAxis, QCPAxis* valueAxis)
 {
+    PROFILE_HERE_N("optimizedLineData");
     Q_ASSERT(begin >= 0 && end <= static_cast<int>(std::ranges::size(keys)));
     Q_ASSERT(begin >= 0 && end <= static_cast<int>(std::ranges::size(values)));
     const int dataCount = end - begin;

--- a/src/datasource/async-pipeline.cpp
+++ b/src/datasource/async-pipeline.cpp
@@ -1,5 +1,6 @@
 #include "async-pipeline.h"
 #include "pipeline-scheduler.h"
+#include "../Profiling.hpp"
 
 QCPAsyncPipelineBase::QCPAsyncPipelineBase(QCPPipelineScheduler* scheduler,
                                              QObject* parent)
@@ -21,20 +22,22 @@ bool QCPAsyncPipelineBase::isBusy() const
 
 void QCPAsyncPipelineBase::onDataChanged()
 {
+    PROFILE_HERE_N("Pipeline::onDataChanged");
     uint64_t gen = ++mGeneration;
     QMutexLocker lock(&mMutex);
     mCache = std::any{};
 
-    auto job = makeJob(mLastViewport, std::any{}, gen);
-    if (!job) return;
-
     if (mJobRunning)
     {
-        mPending = std::move(job);
+        // Data change supersedes any pending viewport change
+        mPending = makeJob(mLastViewport, std::any{}, gen);
+        mPendingViewport = false;
         mPendingPriority = QCPPipelineScheduler::Heavy;
     }
     else
     {
+        auto job = makeJob(mLastViewport, std::any{}, gen);
+        if (!job) return;
         mJobRunning = true;
         mRunningGeneration = gen;
         lock.unlock();
@@ -44,6 +47,7 @@ void QCPAsyncPipelineBase::onDataChanged()
 
 void QCPAsyncPipelineBase::onViewportChanged(const ViewportParams& vp)
 {
+    PROFILE_HERE_N("Pipeline::onViewportChanged");
     if (mKind == TransformKind::ViewportIndependent)
     {
         QMutexLocker lock(&mMutex);
@@ -55,17 +59,17 @@ void QCPAsyncPipelineBase::onViewportChanged(const ViewportParams& vp)
     QMutexLocker lock(&mMutex);
     mLastViewport = vp;
 
-    auto cache = std::move(mCache);
-    auto job = makeJob(vp, std::move(cache), gen);
-    if (!job) return;
-
     if (mJobRunning)
     {
-        mPending = std::move(job);
+        // Defer job creation — cache will be available when current job finishes
+        mPendingViewport = true;
         mPendingPriority = QCPPipelineScheduler::Fast;
     }
     else
     {
+        auto cache = std::move(mCache);
+        auto job = makeJob(vp, std::move(cache), gen);
+        if (!job) return;
         mJobRunning = true;
         mRunningGeneration = gen;
         lock.unlock();
@@ -75,20 +79,43 @@ void QCPAsyncPipelineBase::onViewportChanged(const ViewportParams& vp)
 
 void QCPAsyncPipelineBase::deliverResult(uint64_t generation, std::any cache, std::any result)
 {
+    PROFILE_HERE_N("Pipeline::deliverResult");
     if (mDestroyed->load())
         return;
 
     QMutexLocker lock(&mMutex);
     mCache = std::move(cache);
 
-    if (mPending)
+    if (mPending || mPendingViewport)
     {
-        auto job = std::move(mPending);
-        mPending = nullptr;
         auto priority = mPendingPriority;
         mRunningGeneration = mGeneration.load();
+
+        std::function<void()> job;
+        if (mPending)
+        {
+            // Data change: pre-baked job (cache was cleared)
+            job = std::move(mPending);
+            mPending = nullptr;
+        }
+        else
+        {
+            // Viewport change: create job now with the restored cache
+            mPendingViewport = false;
+            auto jobCache = std::move(mCache);
+            job = makeJob(mLastViewport, std::move(jobCache), mRunningGeneration);
+        }
+
         lock.unlock();
-        mScheduler->submit(priority, std::move(job));
+        if (job)
+        {
+            mScheduler->submit(priority, std::move(job));
+        }
+        else
+        {
+            mJobRunning = false;
+            mPendingViewport = false;
+        }
     }
     else
     {

--- a/src/datasource/async-pipeline.h
+++ b/src/datasource/async-pipeline.h
@@ -54,7 +54,8 @@ protected:
 
     mutable QMutex mMutex;
     std::any mCache;
-    std::function<void()> mPending;
+    std::function<void()> mPending;  // pre-baked job for data changes
+    bool mPendingViewport = false;   // deferred viewport job: created at dispatch with restored cache
     QCPPipelineScheduler::Priority mPendingPriority = QCPPipelineScheduler::Heavy;
     uint64_t mRunningGeneration = 0;
     bool mJobRunning = false;
@@ -63,6 +64,11 @@ protected:
     bool mWasBusy = false;
 
     std::shared_ptr<std::atomic<bool>> mDestroyed;
+
+public:
+    // Only safe to call from the pipeline's thread when no job is running
+    // (e.g. inside a finished() signal handler after deliverResult completes).
+    std::any& cache() { return mCache; }
 };
 
 class QCPAbstractDataSource;

--- a/src/datasource/graph-resampler.h
+++ b/src/datasource/graph-resampler.h
@@ -2,10 +2,12 @@
 #include "abstract-datasource.h"
 #include "soa-datasource.h"
 #include "async-pipeline.h"
+#include "../Profiling.hpp"
 #include <algorithm>
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <thread>
 #include <vector>
 
 namespace qcp::algo {
@@ -108,60 +110,157 @@ inline BinResult binMinMax(
     return out;
 }
 
+// Parallel Level 1 binning: splits source into N chunks with bin-aligned
+// boundaries so each thread writes to disjoint output bins (zero synchronization).
+// Falls back to single-threaded binMinMax when threadCount <= 1.
+inline BinResult binMinMaxParallel(
+    const QCPAbstractDataSource& src,
+    int begin, int end,
+    const QCPRange& keyRange,
+    int numBins)
+{
+    PROFILE_HERE_N("binMinMaxParallel");
+    int threadCount = std::max(1, static_cast<int>(std::thread::hardware_concurrency()) / 2);
+    if (threadCount <= 1 || (end - begin) < 1'000'000)
+        return binMinMax(src, begin, end, keyRange, numBins);
+
+    BinResult out;
+    if (numBins <= 0 || keyRange.size() <= 0)
+        return out;
+
+    out.keys.resize(numBins * 2);
+    out.values.resize(numBins * 2);
+
+    const double binWidth = keyRange.size() / numBins;
+    const double halfWidth = binWidth * 0.5;
+    const double keyLo = keyRange.lower;
+
+    // Initialize all bins: keys are deterministic, values start as NaN
+    for (int b = 0; b < numBins; ++b)
+    {
+        double binCenter = keyLo + (b + 0.5) * binWidth;
+        out.keys[b * 2 + 0] = binCenter;
+        out.keys[b * 2 + 1] = binCenter + halfWidth;
+        out.values[b * 2 + 0] = std::numeric_limits<double>::quiet_NaN();
+        out.values[b * 2 + 1] = std::numeric_limits<double>::quiet_NaN();
+    }
+
+    // Clamp thread count to available bins
+    threadCount = std::min(threadCount, numBins);
+
+    // Worker: iterate source[srcBegin..srcEnd), update bins[binBegin..binEnd)
+    auto worker = [&](int srcBegin, int srcEnd, int binBegin, int binEnd) {
+        for (int i = srcBegin; i < srcEnd; ++i)
+        {
+            double k = src.keyAt(i);
+            double v = src.valueAt(i);
+            if (std::isnan(v) || !std::isfinite(k)) continue;
+
+            int bin = static_cast<int>((k - keyLo) / binWidth);
+            bin = std::clamp(bin, binBegin, binEnd - 1);
+
+            double& mn = out.values[bin * 2 + 0];
+            double& mx = out.values[bin * 2 + 1];
+            if (std::isnan(mn) || v < mn) mn = v;
+            if (std::isnan(mx) || v > mx) mx = v;
+        }
+    };
+
+    // Partition bins evenly across threads, binary-search source for chunk boundaries
+    int binsPerChunk = numBins / threadCount;
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount - 1);
+
+    for (int t = 0; t < threadCount; ++t)
+    {
+        int binBegin = t * binsPerChunk;
+        int binEnd = (t == threadCount - 1) ? numBins : (t + 1) * binsPerChunk;
+
+        // Find source indices that map to this chunk's bin range
+        double chunkKeyLo = keyLo + binBegin * binWidth;
+        double chunkKeyHi = keyLo + binEnd * binWidth;
+        int srcBegin_ = (t == 0) ? begin : src.findBegin(chunkKeyLo, false);
+        int srcEnd_ = (t == threadCount - 1) ? end : src.findEnd(chunkKeyHi, false);
+        srcBegin_ = std::clamp(srcBegin_, begin, end);
+        srcEnd_ = std::clamp(srcEnd_, begin, end);
+
+        if (t < threadCount - 1)
+            threads.emplace_back(worker, srcBegin_, srcEnd_, binBegin, binEnd);
+        else
+            worker(srcBegin_, srcEnd_, binBegin, binEnd); // current thread does last chunk
+    }
+
+    for (auto& t : threads)
+        t.join();
+
+    return out;
+}
+
 struct GraphResamplerCache {
     BinResult level1;
     QCPRange cachedKeyRange;
     int sourceSize = 0;
 };
 
-constexpr int kLevel1TargetBins = 500'000;
+constexpr int kLevel1TargetBins = 100'000;
 constexpr int kResampleThreshold = 10'000'000;
 constexpr int kLevel2PixelMultiplier = 4;
 
-inline std::shared_ptr<QCPAbstractDataSource> hierarchicalResample(
+// L1 build only — heavy, meant for async pipeline.
+// Returns the L1 cache via the std::any, result is nullptr (L2 is done synchronously).
+inline std::shared_ptr<QCPAbstractDataSource> buildL1Cache(
     const QCPAbstractDataSource& src,
-    const ViewportParams& vp,
+    const ViewportParams& /*vp*/,
     std::any& cache)
 {
+    PROFILE_HERE_N("buildL1Cache");
     const int srcSize = src.size();
-    if (srcSize == 0 || srcSize < kResampleThreshold || vp.keyLogScale)
+    if (srcSize == 0 || srcSize < kResampleThreshold)
         return nullptr;
 
     auto* c = std::any_cast<GraphResamplerCache>(&cache);
-    bool cacheValid = c && c->sourceSize == srcSize;
+    if (c && c->sourceSize == srcSize)
+        return nullptr; // L1 already valid
 
-    if (!cacheValid)
-    {
-        bool foundRange = false;
-        QCPRange fullKeyRange = src.keyRange(foundRange);
-        if (!foundRange || fullKeyRange.size() <= 0)
-            return nullptr;
-        int numBins = std::min(kLevel1TargetBins, srcSize / 2);
+    bool foundRange = false;
+    QCPRange fullKeyRange = src.keyRange(foundRange);
+    if (!foundRange || fullKeyRange.size() <= 0)
+        return nullptr;
+    int numBins = std::min(kLevel1TargetBins, srcSize / 2);
 
-        // Bin directly from source — no full copy
-        GraphResamplerCache newCache;
-        newCache.level1 = binMinMax(src, 0, srcSize, fullKeyRange, numBins);
-        newCache.cachedKeyRange = fullKeyRange;
-        newCache.sourceSize = srcSize;
-        cache = std::move(newCache);
-        c = std::any_cast<GraphResamplerCache>(&cache);
-    }
+    GraphResamplerCache newCache;
+    newCache.level1 = binMinMaxParallel(src, 0, srcSize, fullKeyRange, numBins);
+    newCache.cachedKeyRange = fullKeyRange;
+    newCache.sourceSize = srcSize;
+    cache = std::move(newCache);
+    return nullptr;
+}
+
+// L2 viewport resampling — fast, runs synchronously on the main thread.
+// Takes a shared L1 cache (read-only) and the current viewport.
+inline std::shared_ptr<QCPAbstractDataSource> resampleL2(
+    const GraphResamplerCache& l1Cache,
+    const ViewportParams& vp)
+{
+    PROFILE_HERE_N("resampleL2");
+    if (vp.keyLogScale)
+        return nullptr;
 
     int l2Bins = vp.plotWidthPx * kLevel2PixelMultiplier;
     if (l2Bins <= 0) l2Bins = 3200;
 
-    const auto& l1 = c->level1;
+    const auto& l1 = l1Cache.level1;
     int l1Size = static_cast<int>(l1.keys.size());
+    if (l1Size == 0) return nullptr;
 
     auto beginIt = std::lower_bound(l1.keys.begin(), l1.keys.end(), vp.keyRange.lower);
     auto endIt = std::upper_bound(l1.keys.begin(), l1.keys.end(), vp.keyRange.upper);
     int l1Begin = std::max(0, static_cast<int>(beginIt - l1.keys.begin()) - 1);
     int l1End = std::min(l1Size, static_cast<int>(endIt - l1.keys.begin()) + 1);
 
-    // Align to pair boundaries so we never split a min/max pair
-    l1Begin = l1Begin & ~1;          // round down to even
-    l1End = (l1End + 1) & ~1;        // round up to even
-    l1End = std::min(l1End, l1Size); // clamp after rounding
+    l1Begin = l1Begin & ~1;
+    l1End = (l1End + 1) & ~1;
+    l1End = std::min(l1End, l1Size);
 
     if (l1End <= l1Begin)
         return nullptr;
@@ -180,9 +279,28 @@ inline std::shared_ptr<QCPAbstractDataSource> hierarchicalResample(
         }
     }
 
+    if (outKeys.empty()) return nullptr;
+
     return std::make_shared<QCPSoADataSource<
         std::vector<double>, std::vector<double>>>(
         std::move(outKeys), std::move(outVals));
+}
+
+// Legacy combined function (kept for tests) — delegates to the two-phase functions.
+inline std::shared_ptr<QCPAbstractDataSource> hierarchicalResample(
+    const QCPAbstractDataSource& src,
+    const ViewportParams& vp,
+    std::any& cache)
+{
+    PROFILE_HERE_N("hierarchicalResample");
+    const int srcSize = src.size();
+    if (srcSize == 0 || srcSize < kResampleThreshold || vp.keyLogScale)
+        return nullptr;
+
+    buildL1Cache(src, vp, cache);
+    auto* c = std::any_cast<GraphResamplerCache>(&cache);
+    if (!c) return nullptr;
+    return resampleL2(*c, vp);
 }
 
 } // namespace qcp::algo

--- a/src/datasource/soa-datasource.h
+++ b/src/datasource/soa-datasource.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "abstract-datasource.h"
 #include "algorithms.h"
+#include "../Profiling.hpp"
 #include <QtGlobal>
 
 template <IndexableNumericRange KeyContainer, IndexableNumericRange ValueContainer>
@@ -37,12 +38,14 @@ public:
 
     QCPRange keyRange(bool& foundRange, QCP::SignDomain sd = QCP::sdBoth) const override
     {
-        return qcp::algo::keyRange(mKeys, foundRange, sd);
+        PROFILE_HERE_N("SoA::keyRange");
+        return qcp::algo::keyRangeSorted(mKeys, foundRange, sd);
     }
 
     QCPRange valueRange(bool& foundRange, QCP::SignDomain sd = QCP::sdBoth,
                         const QCPRange& inKeyRange = QCPRange()) const override
     {
+        PROFILE_HERE_N("SoA::valueRange");
         return qcp::algo::valueRange(mKeys, mValues, foundRange, sd, inKeyRange);
     }
 

--- a/src/layoutelements/layoutelement-axisrect.cpp
+++ b/src/layoutelements/layoutelement-axisrect.cpp
@@ -32,6 +32,7 @@
 #include "../painting/painter.h"
 #include "../plottables/plottable.h"
 #include "../plottables/plottable-graph.h"
+#include "../Profiling.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisRect
@@ -1345,6 +1346,7 @@ void QCPAxisRect::mouseReleaseEvent(QMouseEvent* event, const QPointF& startPos)
 */
 void QCPAxisRect::wheelEvent(QWheelEvent* event)
 {
+    PROFILE_HERE_N("QCPAxisRect::wheelEvent");
     const double delta = event->angleDelta().y();
     const QPointF pos = event->position();
 

--- a/src/plottables/plottable-graph2.cpp
+++ b/src/plottables/plottable-graph2.cpp
@@ -27,25 +27,23 @@ QCPGraph2::QCPGraph2(QCPAxis* keyAxis, QCPAxis* valueAxis)
     }
 
     connect(&mPipeline, &QCPGraphPipeline::finished,
-            this, [this](uint64_t) {
-                if (parentPlot())
-                    parentPlot()->replot(QCustomPlot::rpQueuedReplot);
-            });
+            this, [this](uint64_t) { onL1Ready(); });
 }
 
 QCPGraph2::~QCPGraph2() = default;
 
-static void ensureResamplingTransform(QCPGraphPipeline& pipeline, int sourceSize)
+static void ensureL1Transform(QCPGraphPipeline& pipeline, int sourceSize)
 {
     if (sourceSize >= qcp::algo::kResampleThreshold)
     {
         if (!pipeline.hasTransform())
         {
-            pipeline.setTransform(TransformKind::ViewportDependent,
+            // Pipeline only builds L1 cache — L2 is done synchronously
+            pipeline.setTransform(TransformKind::ViewportIndependent,
                 [](const QCPAbstractDataSource& src,
                    const ViewportParams& vp,
                    std::any& cache) -> std::shared_ptr<QCPAbstractDataSource> {
-                    return qcp::algo::hierarchicalResample(src, vp, cache);
+                    return qcp::algo::buildL1Cache(src, vp, cache);
                 });
         }
     }
@@ -58,25 +56,72 @@ static void ensureResamplingTransform(QCPGraphPipeline& pipeline, int sourceSize
 void QCPGraph2::setDataSource(std::unique_ptr<QCPAbstractDataSource> source)
 {
     mDataSource = std::move(source);
+    mL1Cache.reset();
+    mL2Result.reset();
+    mL2Dirty = false;
+    mNeedsResampling = mDataSource && mDataSource->size() >= qcp::algo::kResampleThreshold;
     if (mDataSource)
-        ensureResamplingTransform(mPipeline, mDataSource->size());
+        ensureL1Transform(mPipeline, mDataSource->size());
     mPipeline.setSource(mDataSource);
 }
 
 void QCPGraph2::setDataSource(std::shared_ptr<QCPAbstractDataSource> source)
 {
     mDataSource = std::move(source);
+    mL1Cache.reset();
+    mL2Result.reset();
+    mL2Dirty = false;
+    mNeedsResampling = mDataSource && mDataSource->size() >= qcp::algo::kResampleThreshold;
     if (mDataSource)
-        ensureResamplingTransform(mPipeline, mDataSource->size());
+        ensureL1Transform(mPipeline, mDataSource->size());
     mPipeline.setSource(mDataSource);
 }
 
 void QCPGraph2::dataChanged()
 {
+    bool wasResampling = mNeedsResampling;
+    mNeedsResampling = mDataSource && mDataSource->size() >= qcp::algo::kResampleThreshold;
+
+    if (mNeedsResampling && !wasResampling && mDataSource)
+        ensureL1Transform(mPipeline, mDataSource->size());
+
     if (mPipeline.hasTransform())
+    {
+        mL1Cache.reset();
+        mL2Result.reset();
+        mL2Dirty = false;
         mPipeline.onDataChanged();
+    }
     else if (mParentPlot)
         mParentPlot->replot();
+}
+
+void QCPGraph2::onL1Ready()
+{
+    PROFILE_HERE_N("QCPGraph2::onL1Ready");
+    // Extract L1 cache from pipeline and store locally
+    auto& pipelineCache = mPipeline.cache();
+    auto* c = std::any_cast<qcp::algo::GraphResamplerCache>(&pipelineCache);
+    if (c && c->sourceSize > 0)
+    {
+        mL1Cache = std::make_shared<qcp::algo::GraphResamplerCache>(std::move(*c));
+        pipelineCache = std::any{}; // clear pipeline copy
+        mL2Dirty = true; // will be rebuilt at next draw()
+    }
+    if (parentPlot())
+        parentPlot()->replot(QCustomPlot::rpQueuedReplot);
+}
+
+void QCPGraph2::rebuildL2(const ViewportParams& vp)
+{
+    PROFILE_HERE_N("QCPGraph2::rebuildL2");
+    if (!mL1Cache) return;
+    if (vp.keyLogScale)
+    {
+        mL2Result.reset(); // L2 not supported for log scale — fall back to raw data
+        return;
+    }
+    mL2Result = qcp::algo::resampleL2(*mL1Cache, vp);
 }
 
 // --- QCPPlottableInterface1D ---
@@ -177,6 +222,19 @@ double QCPGraph2::selectTest(const QPointF& pos, bool onlySelectable, QVariant* 
     if (!mKeyAxis || !mValueAxis)
         return -1;
 
+    // Fast path: when details aren't needed (e.g. wheel events), just check
+    // if the mouse is inside the clip rect rather than doing per-point testing.
+    if (!details)
+    {
+        auto* axisRect = mKeyAxis->axisRect();
+        if (axisRect && axisRect->rect().contains(pos.toPoint()))
+            return mParentPlot->selectionTolerance() * 0.99;
+        return -1;
+    }
+
+    // Use resampled data for hit testing when available (O(k) instead of O(n))
+    const QCPAbstractDataSource* ds = mL2Result ? mL2Result.get() : mDataSource.get();
+
     double posKeyMin, posKeyMax, dummy;
     pixelsToCoords(
         pos - QPointF(mParentPlot->selectionTolerance(), mParentPlot->selectionTolerance()),
@@ -187,8 +245,8 @@ double QCPGraph2::selectTest(const QPointF& pos, bool onlySelectable, QVariant* 
     if (posKeyMin > posKeyMax)
         qSwap(posKeyMin, posKeyMax);
 
-    int begin = mDataSource->findBegin(posKeyMin, true);
-    int end = mDataSource->findEnd(posKeyMax, true);
+    int begin = ds->findBegin(posKeyMin, true);
+    int end = ds->findEnd(posKeyMax, true);
     if (begin == end)
         return -1;
 
@@ -199,8 +257,8 @@ double QCPGraph2::selectTest(const QPointF& pos, bool onlySelectable, QVariant* 
 
     for (int i = begin; i < end; ++i)
     {
-        double k = mDataSource->keyAt(i);
-        double v = mDataSource->valueAt(i);
+        double k = ds->keyAt(i);
+        double v = ds->valueAt(i);
         if (keyRange.contains(k) && valueRange.contains(v))
         {
             double distSqr = QCPVector2D(coordsToPixels(k, v) - pos).lengthSquared();
@@ -223,6 +281,7 @@ double QCPGraph2::selectTest(const QPointF& pos, bool onlySelectable, QVariant* 
 
 QCPRange QCPGraph2::getKeyRange(bool& foundRange, QCP::SignDomain inSignDomain) const
 {
+    PROFILE_HERE_N("QCPGraph2::getKeyRange");
     if (!mDataSource || mDataSource->empty())
     {
         foundRange = false;
@@ -234,6 +293,7 @@ QCPRange QCPGraph2::getKeyRange(bool& foundRange, QCP::SignDomain inSignDomain) 
 QCPRange QCPGraph2::getValueRange(bool& foundRange, QCP::SignDomain inSignDomain,
                                    const QCPRange& inKeyRange) const
 {
+    PROFILE_HERE_N("QCPGraph2::getValueRange");
     if (!mDataSource || mDataSource->empty())
     {
         foundRange = false;
@@ -390,13 +450,33 @@ void QCPGraph2::draw(QCPPainter* painter)
     if (!mKeyAxis || !mValueAxis || !mDataSource)
         return;
 
-    const QCPAbstractDataSource* ds = mPipeline.hasTransform()
-        ? mPipeline.result()
-        : nullptr;
-    if (!ds)
-        ds = mDataSource.get();
+    // Lazy L2 rebuild: coalesces all viewport changes since last draw into one rebuild
+    if (mL2Dirty && mL1Cache)
+    {
+        auto* axisRect = mKeyAxis->axisRect();
+        if (axisRect)
+        {
+            ViewportParams vp;
+            vp.keyRange = mKeyAxis->range();
+            vp.valueRange = mValueAxis->range();
+            vp.plotWidthPx = axisRect->width();
+            vp.plotHeightPx = axisRect->height();
+            vp.keyLogScale = (mKeyAxis->scaleType() == QCPAxis::stLogarithmic);
+            vp.valueLogScale = (mValueAxis->scaleType() == QCPAxis::stLogarithmic);
+            rebuildL2(vp);
+        }
+        mL2Dirty = false;
+    }
+
+    // Use L2 resampled data if available, otherwise fall back to raw data.
+    // Raw data is used for small datasets (below threshold), log-scale keys,
+    // or while L1 is still building asynchronously.
+    const QCPAbstractDataSource* ds = mL2Result ? mL2Result.get() : mDataSource.get();
     if (!ds || ds->empty())
         return;
+
+    PROFILE_PASS_VALUE(ds->size());
+
     if (mKeyAxis->range().size() <= 0)
         return;
     if (mLineStyle == lsNone && mScatterStyle.isNone())
@@ -504,17 +584,8 @@ void QCPGraph2::drawLegendIcon(QCPPainter* painter, const QRectF& rect) const
 
 void QCPGraph2::onViewportChanged()
 {
-    if (!mKeyAxis || !mValueAxis) return;
-    auto* axisRect = mKeyAxis->axisRect();
-    if (!axisRect) return;
-
-    ViewportParams vp;
-    vp.keyRange = mKeyAxis->range();
-    vp.valueRange = mValueAxis->range();
-    vp.plotWidthPx = axisRect->width();
-    vp.plotHeightPx = axisRect->height();
-    vp.keyLogScale = (mKeyAxis->scaleType() == QCPAxis::stLogarithmic);
-    vp.valueLogScale = (mValueAxis->scaleType() == QCPAxis::stLogarithmic);
-
-    mPipeline.onViewportChanged(vp);
+    // Just mark L2 as needing rebuild — actual rebuild happens lazily in draw()
+    // to coalesce multiple rangeChanged signals per frame (pan fires many mouse moves)
+    if (mL1Cache)
+        mL2Dirty = true;
 }

--- a/src/plottables/plottable-graph2.h
+++ b/src/plottables/plottable-graph2.h
@@ -4,6 +4,7 @@
 #include "datasource/abstract-datasource.h"
 #include "datasource/soa-datasource.h"
 #include "datasource/async-pipeline.h"
+#include "datasource/graph-resampler.h"
 #include <memory>
 #include <span>
 
@@ -105,6 +106,18 @@ protected:
 private:
     std::shared_ptr<QCPAbstractDataSource> mDataSource;
     QCPGraphPipeline mPipeline;
+
+    // Two-phase resampling: L1 built async, L2 computed lazily at draw time
+    std::shared_ptr<qcp::algo::GraphResamplerCache> mL1Cache;
+    std::shared_ptr<QCPAbstractDataSource> mL2Result;
+    bool mNeedsResampling = false;
+    bool mL2Dirty = false;
+
+    void onL1Ready();
+    void rebuildL2(const ViewportParams& vp);
+
+    friend class TestPipeline;
+
     LineStyle mLineStyle = lsLine;
     QCPScatterStyle mScatterStyle;
     int mScatterSkip = 0;

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -742,12 +742,21 @@ void TestPipeline::graph2HierarchicalResamplingActivates()
 
     QVERIFY(g->pipeline().hasTransform());
 
+    // Wait for async L1 build to finish
     QTRY_VERIFY_WITH_TIMEOUT(spy.count() >= 1, 30000);
 
-    auto* result = g->pipeline().result();
-    QVERIFY(result);
-    QVERIFY(result->size() > 0);
-    QVERIFY(result->size() < N / 10);
+    // After L1 delivery, onL1Ready runs L2 synchronously.
+    // Trigger a replot to exercise the draw path with resampled data.
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    // Pipeline result is nullptr (L1-only transform returns nullptr).
+    QVERIFY(g->pipeline().result() == nullptr);
+    QVERIFY(g->dataSource()->size() == N);
+
+    // Verify L2 was actually built and is much smaller than raw data.
+    QVERIFY(g->mL2Result);
+    QVERIFY(g->mL2Result->size() > 0);
+    QVERIFY(g->mL2Result->size() < N / 10);
 }
 
 void TestPipeline::graph2SmallDataNoResampling()
@@ -844,6 +853,144 @@ void TestPipeline::graphResamplerNonFiniteKeysSkipped()
     // Only finite keys (0, 2, 4) should contribute → min=10, max=50
     QCOMPARE(outVals[0], 10.0);
     QCOMPARE(outVals[1], 50.0);
+}
+
+void TestPipeline::graphResamplerParallelMatchesSingleThreaded()
+{
+    // Generate 2M points (above the 1M parallel threshold in binMinMaxParallel)
+    const int N = 2'000'000;
+    std::vector<double> keys(N), vals(N);
+    for (int i = 0; i < N; ++i)
+    {
+        keys[i] = i;
+        vals[i] = std::sin(i * 0.0001) * 100.0;
+    }
+
+    auto src = std::make_shared<QCPSoADataSource<
+        std::vector<double>, std::vector<double>>>(std::move(keys), std::move(vals));
+
+    QCPRange fullRange(0, N - 1);
+    int numBins = 1000;
+
+    auto sequential = qcp::algo::binMinMax(*src, 0, N, fullRange, numBins);
+    auto parallel = qcp::algo::binMinMaxParallel(*src, 0, N, fullRange, numBins);
+
+    QCOMPARE(parallel.keys.size(), sequential.keys.size());
+    QCOMPARE(parallel.values.size(), sequential.values.size());
+
+    for (size_t i = 0; i < sequential.keys.size(); ++i)
+        QCOMPARE(parallel.keys[i], sequential.keys[i]);
+
+    for (size_t i = 0; i < sequential.values.size(); ++i)
+    {
+        if (std::isnan(sequential.values[i]))
+            QVERIFY(std::isnan(parallel.values[i]));
+        else
+            QCOMPARE(parallel.values[i], sequential.values[i]);
+    }
+}
+
+// --- L2 lazy rebuild tests ---
+
+void TestPipeline::graph2L2RebuildDeferredToDraw()
+{
+    // Verify that changing the viewport does NOT immediately rebuild L2,
+    // but that L2 IS rebuilt when draw() runs (via replot).
+    auto* g = new QCPGraph2(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10'000'001;
+    auto source = std::make_shared<SyntheticLargeSource>(N);
+
+    QSignalSpy spy(&g->pipeline(), &QCPGraphPipeline::finished);
+    mPlot->xAxis->setRange(0, N - 1);
+    mPlot->yAxis->setRange(-1, 1);
+    g->setDataSource(source);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    // Wait for L1 build
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() >= 1, 30000);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+    QVERIFY(g->mL1Cache);
+    QVERIFY(g->mL2Result);
+
+    auto oldL2 = g->mL2Result;
+
+    // Change viewport — L2 should NOT be rebuilt yet (just flagged dirty)
+    mPlot->xAxis->setRange(0, N / 2);
+    QVERIFY(g->mL2Dirty);
+    QCOMPARE(g->mL2Result, oldL2); // still the old L2
+
+    // Now replot — draw() should rebuild L2
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+    QVERIFY(!g->mL2Dirty);
+    QVERIFY(g->mL2Result);
+    QVERIFY(g->mL2Result != oldL2); // rebuilt with new viewport
+}
+
+void TestPipeline::graph2L2CoalescesMultipleViewportChanges()
+{
+    // Simulate rapid pan: many range changes, one replot.
+    // L2 should only be built once (at draw time), not per range change.
+    auto* g = new QCPGraph2(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10'000'001;
+    auto source = std::make_shared<SyntheticLargeSource>(N);
+
+    QSignalSpy spy(&g->pipeline(), &QCPGraphPipeline::finished);
+    mPlot->xAxis->setRange(0, N - 1);
+    mPlot->yAxis->setRange(-1, 1);
+    g->setDataSource(source);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() >= 1, 30000);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+    QVERIFY(g->mL2Result);
+
+    auto oldL2 = g->mL2Result;
+
+    // Simulate 10 rapid viewport changes (like 10 mouse move events during pan)
+    for (int i = 0; i < 10; ++i)
+    {
+        double offset = i * 1000.0;
+        mPlot->xAxis->setRange(offset, offset + N / 2);
+    }
+
+    // L2 should still be the old one — dirty flag set but not yet rebuilt
+    QVERIFY(g->mL2Dirty);
+    QCOMPARE(g->mL2Result, oldL2);
+
+    // Single replot rebuilds L2 once with the final viewport
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+    QVERIFY(!g->mL2Dirty);
+    QVERIFY(g->mL2Result != oldL2);
+}
+
+void TestPipeline::graph2L2DirtyAfterL1Ready()
+{
+    // When L1 finishes, L2 should be marked dirty (not built inline).
+    auto* g = new QCPGraph2(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10'000'001;
+    auto source = std::make_shared<SyntheticLargeSource>(N);
+
+    mPlot->xAxis->setRange(0, N - 1);
+    mPlot->yAxis->setRange(-1, 1);
+
+    QSignalSpy spy(&g->pipeline(), &QCPGraphPipeline::finished);
+    g->setDataSource(source);
+
+    // Before L1 finishes: no L1 cache, no L2, not dirty
+    QVERIFY(!g->mL1Cache);
+    QVERIFY(!g->mL2Result);
+    QVERIFY(!g->mL2Dirty);
+
+    // Wait for L1
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() >= 1, 30000);
+    // Process the queued replot from onL1Ready
+    QCoreApplication::processEvents();
+
+    // After L1 delivery: L1 cache exists, L2 dirty flag was set,
+    // and the queued replot should have rebuilt L2
+    QVERIFY(g->mL1Cache);
+    QVERIFY(g->mL2Result);
+    QVERIFY(!g->mL2Dirty); // cleared by draw()
 }
 
 // --- Histogram binner tests ---

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -54,6 +54,12 @@ private slots:
     void graphResamplerBinMinMaxKeyPositions();
     void graphResamplerBinMinMaxZeroBins();
     void graphResamplerNonFiniteKeysSkipped();
+    void graphResamplerParallelMatchesSingleThreaded();
+
+    // L2 lazy rebuild (deferred to draw)
+    void graph2L2RebuildDeferredToDraw();
+    void graph2L2CoalescesMultipleViewportChanges();
+    void graph2L2DirtyAfterL1Ready();
 
     // Histogram binner
     void bin2dBasicCounts();

--- a/tests/big_data_for_tracy/mainwindow.cpp
+++ b/tests/big_data_for_tracy/mainwindow.cpp
@@ -4,31 +4,31 @@
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 {
+    auto* plot = new QCustomPlot(this);
+    plot->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom
+                          | QCP::iSelectPlottables | QCP::iSelectAxes);
 
-    auto plotBuilder = [this](std::size_t points= 10'000'000){
-        auto plot = new QCustomPlot(this);
+    constexpr int N = 50'000'000;
+    std::vector<double> keys(N), vals(N);
+    for (int i = 0; i < N; ++i)
+    {
+        double t = i * 1e-6;
+        keys[i] = t;
+        vals[i] = std::sin(t * 6.28 * 0.5)
+                + 0.3 * std::sin(t * 6.28 * 50.0)
+                + 0.1 * std::sin(t * 6.28 * 5000.0);
+    }
 
-        plot->addGraph();
+    auto* g = new QCPGraph2(plot->xAxis, plot->yAxis);
+    g->setData(std::move(keys), std::move(vals));
+    g->setPen(QPen(QColor(31, 119, 180), 1));
 
-        // Simulate a large data set
-        for (auto i = 0UL; i < points; ++i) {
-            plot->graph(0)->addData(i, qSin(i * 0.001));
-        }
-        plot->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom | QCP::iSelectPlottables | QCP::iSelectAxes | QCP::iSelectLegend);
-        plot->xAxis->rescale();
-        plot->yAxis->rescale();
-        plot->plotLayout()->insertRow(0);
-        plot->plotLayout()->addElement(0,0, new QCPTextElement(plot, "Plot"));
-        plot->replot();
-        return plot;
-    };
-    setCentralWidget(new QWidget(this));
-    mLayout = new QVBoxLayout(centralWidget());
-    mLayout->setContentsMargins(0, 0, 0, 0);
-    mLayout->setSpacing(0);
-    mLayout->addWidget(plotBuilder(10'000'000));
-    mLayout->addWidget(plotBuilder(10'000'000));
+    plot->xAxis->setLabel("Time (s)");
+    plot->yAxis->setLabel("Amplitude");
+    plot->rescaleAxes();
+    plot->replot();
 
+    setCentralWidget(plot);
 }
 
 MainWindow::~MainWindow()

--- a/tests/manual/gallery/main.cpp
+++ b/tests/manual/gallery/main.cpp
@@ -1,6 +1,8 @@
 #include <QApplication>
 #include <QMainWindow>
+#include <QPushButton>
 #include <QTabWidget>
+#include <QThread>
 #include <QVBoxLayout>
 #include <QTimer>
 #include <cmath>
@@ -785,6 +787,64 @@ static QWidget* createRealtimeGraphTab()
     return wrapPlot(plot);
 }
 
+// ── Tab: Massive Graph2 (500M points) — lazy, allocates ~8GB on first show ──
+
+static QWidget* createMassiveGraphTab()
+{
+    auto* placeholder = new QWidget;
+    auto* layout = new QVBoxLayout(placeholder);
+    auto* btn = new QPushButton("Load 500M points (~8 GB RAM)");
+    btn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    layout->addWidget(btn, 0, Qt::AlignCenter);
+
+    struct GeneratedData {
+        std::vector<double> keys, vals;
+    };
+
+    QObject::connect(btn, &QPushButton::clicked, placeholder, [layout, btn]() {
+        btn->setEnabled(false);
+        btn->setText("Generating 500M points...");
+
+        auto data = std::make_shared<GeneratedData>();
+        auto* thread = QThread::create([data]() {
+            constexpr int N = 500'000'000;
+            data->keys.resize(N);
+            data->vals.resize(N);
+            for (int i = 0; i < N; ++i)
+            {
+                double t = i * 1e-6;
+                data->keys[i] = t;
+                data->vals[i] = std::sin(t * 6.28 * 0.5)
+                              + 0.3 * std::sin(t * 6.28 * 50.0)
+                              + 0.1 * std::sin(t * 6.28 * 5000.0);
+            }
+        });
+
+        thread->setParent(btn->parentWidget());
+        QObject::connect(thread, &QThread::finished, btn->parentWidget(), [layout, btn, thread, data]() {
+            auto* plot = makePlot();
+            auto* g = new QCPGraph2(plot->xAxis, plot->yAxis);
+            g->setData(std::move(data->keys), std::move(data->vals));
+            g->setPen(QPen(QColor(31, 119, 180), 1));
+            g->setName("500M points");
+
+            plot->xAxis->setLabel("Time (s)");
+            plot->yAxis->setLabel("Amplitude");
+            plot->legend->setVisible(true);
+            plot->rescaleAxes();
+            plot->replot();
+
+            btn->deleteLater();
+            layout->addWidget(wrapPlot(plot));
+            thread->deleteLater();
+        });
+
+        thread->start();
+    });
+
+    return placeholder;
+}
+
 // ── Tab: Histogram2D ────────────────────────────────────────────────────────
 
 static QWidget* createHistogram2DTab()
@@ -900,6 +960,7 @@ int main(int argc, char* argv[])
     tabs->addTab(createRealtimeColorMapTab(), "Realtime ColorMap2");
     tabs->addTab(createRealtimeGraphTab(),   "Realtime Graph2");
     tabs->addTab(createThemeTab(),       "Dark Theme");
+    tabs->addTab(createMassiveGraphTab(), "Graph2 500M pts (~8GB)");
     tabs->addTab(createHistogram2DTab(),    "Histogram2D");
     tabs->addTab(createHistogram2DLogTab(), "Histogram2D (log)");
 


### PR DESCRIPTION
## Summary

- **Two-phase hierarchical resampling** for QCPGraph2 with massive datasets (>10M points): async L1 binning (100k bins, parallel) on worker thread, synchronous L2 viewport resampling (~8k points) on main thread
- **Fix wheel zoom lag**: `selectTest()` O(1) fast path for wheel events — axis rect containment check instead of per-point testing on 50M+ raw data
- **Fix pan lag**: L2 rebuild deferred to `draw()` time, coalescing all `rangeChanged` signals per frame into a single rebuild (was rebuilding synchronously on every mouse move event)
- **O(1) key range** for sorted SoA data via `keyRangeSorted` (was O(n) full scan)
- **Parallel L1 binning** (`binMinMaxParallel`) with bin-aligned partitioning for zero-synchronization multi-threading
- **Gallery tab** with 500M point stress test (threaded data generation)
- **Tests**: L2 lazy rebuild deferral, coalescing verification, parallel binning correctness

## Test plan

- [x] All unit tests pass (including 3 new L2 lazy rebuild tests)
- [x] Manual test: wheel zoom on 50M+ point dataset is responsive
- [x] Manual test: pan is smooth (no per-mouse-event L2 rebuilds)
- [x] Manual test: gallery "Graph2 500M pts" tab loads and interacts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)