### PR TITLE
fix: export (PDF/pixmap) renders QCPColorMap2 and QCPHistogram2D

### DIFF
--- a/src/datasource/async-pipeline.h
+++ b/src/datasource/async-pipeline.h
@@ -122,6 +122,28 @@ public:
 
     bool hasTransform() const { return !!mTransform; }
 
+    // Run the transform synchronously (blocking) and store the result.
+    // Use this during export (savePdf/toPixmap) where the event loop is not running.
+    bool runSynchronously(const ViewportParams& vp)
+    {
+        QMutexLocker lock(&mMutex);
+        if (!mSource || !mTransform) return false;
+        auto source = mSource;
+        auto transform = mTransform;
+        auto cache = std::move(mCache);
+        lock.unlock();
+
+        auto out = transform(*source, vp, cache);
+        if (!out) return false;
+
+        lock.relock();
+        mCache = std::move(cache);
+        lock.unlock();
+
+        mResult = std::move(out);
+        return true;
+    }
+
     void clearTransform()
     {
         mTransform = {};

--- a/src/datasource/async-pipeline.h
+++ b/src/datasource/async-pipeline.h
@@ -134,12 +134,12 @@ public:
         lock.unlock();
 
         auto out = transform(*source, vp, cache);
-        if (!out) return false;
 
         lock.relock();
         mCache = std::move(cache);
         lock.unlock();
 
+        if (!out) return false;
         mResult = std::move(out);
         return true;
     }

--- a/src/plottables/plottable-colormap2.cpp
+++ b/src/plottables/plottable-colormap2.cpp
@@ -216,9 +216,28 @@ void QCPColorMap2::draw(QCPPainter* painter)
     auto* resampledData = mPipeline.result();
     if (!resampledData)
     {
-        if (mDataSource)
+        if (!mDataSource) return;
+        if (painter->modes().testFlag(QCPPainter::pmNoCaching))
+        {
+            // Export path: run transform synchronously since event loop is not pumped
+            ViewportParams vp;
+            vp.keyRange = mKeyAxis->range();
+            vp.valueRange = mValueAxis->range();
+            auto* axisRect = mKeyAxis->axisRect();
+            vp.plotWidthPx = axisRect ? axisRect->width() : 800;
+            vp.plotHeightPx = axisRect ? axisRect->height() : 600;
+            vp.keyLogScale = (mKeyAxis->scaleType() == QCPAxis::stLogarithmic);
+            vp.valueLogScale = (mValueAxis->scaleType() == QCPAxis::stLogarithmic);
+            if (!mPipeline.runSynchronously(vp))
+                return;
+            resampledData = mPipeline.result();
+            if (!resampledData) return;
+        }
+        else
+        {
             onViewportChanged();
-        return;
+            return;
+        }
     }
 
     if (mRenderer.mapImageInvalidated())

--- a/src/plottables/plottable-histogram2d.cpp
+++ b/src/plottables/plottable-histogram2d.cpp
@@ -204,9 +204,24 @@ void QCPHistogram2D::draw(QCPPainter* painter)
     auto* binnedData = mPipeline.result();
     if (!binnedData)
     {
-        if (mDataSource && !mPipeline.isBusy())
-            mPipeline.onDataChanged();
-        return;
+        if (!mDataSource) return;
+        if (painter->modes().testFlag(QCPPainter::pmNoCaching))
+        {
+            // Export path: run transform synchronously since event loop is not pumped
+            ViewportParams vp;
+            vp.keyRange = mKeyAxis->range();
+            vp.valueRange = mValueAxis->range();
+            if (!mPipeline.runSynchronously(vp))
+                return;
+            binnedData = mPipeline.result();
+            if (!binnedData) return;
+        }
+        else
+        {
+            if (!mPipeline.isBusy())
+                mPipeline.onDataChanged();
+            return;
+        }
     }
 
     if (mRenderer.mapImageInvalidated())

--- a/tests/auto/test-datasource2d/test-datasource2d.cpp
+++ b/tests/auto/test-datasource2d/test-datasource2d.cpp
@@ -4,6 +4,7 @@
 #include <datasource/soa-datasource-2d.h>
 #include <datasource/resample.h>
 #include <QtTest/QtTest>
+#include <QTemporaryFile>
 #include <cmath>
 #include <span>
 
@@ -791,4 +792,65 @@ void TestDataSource2D::colormap2ColorScaleSync()
     cm->setDataRange(QCPRange(0, 10));
     QCOMPARE(cs->dataRange().lower, 0.0);
     QCOMPARE(cs->dataRange().upper, 10.0);
+}
+
+void TestDataSource2D::colormap2ExportToPixmap()
+{
+    // Regression test: toPixmap() must render QCPColorMap2 even when the async
+    // pipeline hasn't delivered yet (synchronous fallback path).
+    mPlot->resize(400, 300);
+    auto* cm = new QCPColorMap2(mPlot->xAxis, mPlot->yAxis);
+
+    std::vector<double> x = {0.0, 1.0, 2.0, 3.0, 4.0};
+    std::vector<double> y = {0.0, 1.0, 2.0};
+    std::vector<double> z(15);
+    for (int i = 0; i < 5; ++i)
+        for (int j = 0; j < 3; ++j)
+            z[i * 3 + j] = i * 3.0 + j;
+    cm->setData(std::move(x), std::move(y), std::move(z));
+    cm->setGradient(QCPColorGradient(QCPColorGradient::gpJet));
+    cm->setDataRange(QCPRange(0, 14));
+    cm->rescaleAxes();
+
+    // Export immediately — no event loop pumping, so async pipeline has no result
+    QPixmap pix = mPlot->toPixmap(400, 300);
+    QVERIFY(!pix.isNull());
+
+    // Verify the colormap actually rendered: the center of the plot area should
+    // not be the default white background
+    QImage img = pix.toImage();
+    QColor center = img.pixelColor(img.width() / 2, img.height() / 2);
+    QVERIFY(center != Qt::white);
+}
+
+void TestDataSource2D::colormap2ExportToPdf()
+{
+    // Regression test: savePdf() must render QCPColorMap2 via synchronous fallback.
+    mPlot->resize(400, 300);
+    auto* cm = new QCPColorMap2(mPlot->xAxis, mPlot->yAxis);
+
+    std::vector<double> x = {0.0, 1.0, 2.0, 3.0, 4.0};
+    std::vector<double> y = {0.0, 1.0, 2.0};
+    std::vector<double> z(15);
+    for (int i = 0; i < 5; ++i)
+        for (int j = 0; j < 3; ++j)
+            z[i * 3 + j] = i * 3.0 + j;
+    cm->setData(std::move(x), std::move(y), std::move(z));
+    cm->setGradient(QCPColorGradient(QCPColorGradient::gpJet));
+    cm->setDataRange(QCPRange(0, 14));
+    cm->rescaleAxes();
+
+    // Export to PDF immediately — no event loop pumping
+    QTemporaryFile tmpFile;
+    tmpFile.setFileTemplate(QDir::tempPath() + QStringLiteral("/neoqcp_test_XXXXXX.pdf"));
+    QVERIFY(tmpFile.open());
+    QString path = tmpFile.fileName();
+    tmpFile.close();
+
+    bool ok = mPlot->savePdf(path);
+    QVERIFY(ok);
+
+    QFileInfo fi(path);
+    // A PDF with rendered content should be substantially larger than an empty one
+    QVERIFY(fi.size() > 1000);
 }

--- a/tests/auto/test-datasource2d/test-datasource2d.h
+++ b/tests/auto/test-datasource2d/test-datasource2d.h
@@ -51,6 +51,8 @@ private slots:
     void colormap2Render();
     void colormap2AxisRescale();
     void colormap2ColorScaleSync();
+    void colormap2ExportToPixmap();
+    void colormap2ExportToPdf();
 
 private:
     QCustomPlot* mPlot = nullptr;


### PR DESCRIPTION
## Summary
- QCPColorMap2 and QCPHistogram2D use async pipelines (Qt::QueuedConnection) to deliver resampled/binned data, but the export path (savePdf/toPixmap) is synchronous — no event loop runs, so `result()` is always null and `draw()` skips rendering
- Added `QCPAsyncPipeline::runSynchronously(vp)` that executes the transform inline and stores the result directly
- In both plottables' `draw()`, detect export mode via `pmNoCaching` flag and use the synchronous fallback

## Test plan
- [x] Added `colormap2ExportToPixmap` — verifies toPixmap() renders colormap content (center pixel != white)
- [x] Added `colormap2ExportToPdf` — verifies savePdf() produces a non-trivial PDF file
- [x] Full test suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)