### PR TITLE
perf: optimize rendering for macOS Metal / Apple Silicon

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -426,7 +426,9 @@ QCustomPlot::QCustomPlot(QWidget* parent)
         , mReplotTimeAverage(0)
 {
     setAttribute(Qt::WA_NoMousePropagation);
-    setSampleCount(4); // 4x MSAA for smooth GPU-rendered geometry
+    // Default MSAA off — HiDPI displays already provide sub-pixel smoothness, and 4x
+    // MSAA quadruples memory bandwidth. Users can override via setSampleCount() if needed.
+    setSampleCount(1);
     setFocusPolicy(Qt::ClickFocus);
     setMouseTracking(true);
     QLocale currentLocale = locale();
@@ -2666,10 +2668,7 @@ void QCustomPlot::render(QRhiCommandBuffer* cb)
 
     cb->beginPass(renderTarget(), clearColor, { 1.0f, 0 }, updates);
 
-    cb->setGraphicsPipeline(mCompositePipeline);
-    cb->setViewport({ 0, 0, float(outputSize.width()), float(outputSize.height()) });
     const QRhiCommandBuffer::VertexInput vbufBinding(mQuadVertexBuffer, 0);
-    cb->setVertexInput(0, 1, &vbufBinding, mQuadIndexBuffer, 0, QRhiCommandBuffer::IndexUInt16);
 
     // Iterate over layers (not paint buffers) — mPaintBuffers and mLayers are NOT 1:1.
     // Multiple logical layers share a single paint buffer. Track which buffers we've
@@ -2685,26 +2684,25 @@ void QCustomPlot::render(QRhiCommandBuffer* cb)
             {
                 compositedBuffers.insert(pb.data());
                 auto* rhiBuffer = static_cast<QCPPaintBufferRhi*>(pb.data());
+                if (rhiBuffer->texture())
                 {
-                    if (rhiBuffer->texture())
+                    if (!rhiBuffer->srb() || !rhiBuffer->srbMatchesTexture())
                     {
-                        if (!rhiBuffer->srb() || !rhiBuffer->srbMatchesTexture())
-                        {
-                            auto* srb = mRhi->newShaderResourceBindings();
-                            srb->setBindings({
-                                QRhiShaderResourceBinding::sampledTexture(
-                                    0, QRhiShaderResourceBinding::FragmentStage,
-                                    rhiBuffer->texture(), mSampler)
-                            });
-                            srb->create();
-                            rhiBuffer->setSrb(srb, rhiBuffer->texture());
-                        }
-                        cb->setGraphicsPipeline(mCompositePipeline);
-                        cb->setShaderResources(rhiBuffer->srb());
-                        cb->setVertexInput(0, 1, &vbufBinding, mQuadIndexBuffer, 0,
-                                           QRhiCommandBuffer::IndexUInt16);
-                        cb->drawIndexed(6);
+                        auto* srb = mRhi->newShaderResourceBindings();
+                        srb->setBindings({
+                            QRhiShaderResourceBinding::sampledTexture(
+                                0, QRhiShaderResourceBinding::FragmentStage,
+                                rhiBuffer->texture(), mSampler)
+                        });
+                        srb->create();
+                        rhiBuffer->setSrb(srb, rhiBuffer->texture());
                     }
+                    cb->setGraphicsPipeline(mCompositePipeline);
+                    cb->setViewport({0, 0, float(outputSize.width()), float(outputSize.height())});
+                    cb->setShaderResources(rhiBuffer->srb());
+                    cb->setVertexInput(0, 1, &vbufBinding, mQuadIndexBuffer, 0,
+                                       QRhiCommandBuffer::IndexUInt16);
+                    cb->drawIndexed(6);
                 }
             }
         }
@@ -2713,29 +2711,14 @@ void QCustomPlot::render(QRhiCommandBuffer* cb)
         for (auto* crl : mColormapRhiLayers)
         {
             if (crl->layer() == layer && crl->hasContent())
-            {
                 crl->render(cb, outputSize);
-
-                cb->setGraphicsPipeline(mCompositePipeline);
-                cb->setViewport({0, 0, float(outputSize.width()), float(outputSize.height())});
-                cb->setVertexInput(0, 1, &vbufBinding, mQuadIndexBuffer, 0,
-                                   QRhiCommandBuffer::IndexUInt16);
-            }
         }
 
         // Draw GPU plottable geometry for this layer (after its paint buffer)
         if (auto* prl = mPlottableRhiLayers.value(layer, nullptr))
         {
             if (prl->hasGeometry())
-            {
                 prl->render(cb, outputSize);
-
-                // Restore composite pipeline state for next layer
-                cb->setGraphicsPipeline(mCompositePipeline);
-                cb->setViewport({0, 0, float(outputSize.width()), float(outputSize.height())});
-                cb->setVertexInput(0, 1, &vbufBinding, mQuadIndexBuffer, 0,
-                                   QRhiCommandBuffer::IndexUInt16);
-            }
         }
     }
 

--- a/src/painting/colormap-renderer.cpp
+++ b/src/painting/colormap-renderer.cpp
@@ -7,6 +7,7 @@
 #include <layoutelements/layoutelement-axisrect.h>
 #include <layer.h>
 #include <Profiling.hpp>
+#include <utility>
 #include <vector>
 
 QCPColormapRenderer::QCPColormapRenderer(QCPAbstractPlottable* owner)
@@ -93,7 +94,9 @@ void QCPColormapRenderer::updateMapImage(const QCPColorMapData* data, NormalizeF
                            1, mDataScaleType == QCPAxis::stLogarithmic);
     }
 
-    mMapImage = argbImage.convertToFormat(QImage::Format_RGBA8888_Premultiplied);
+    // Keep native ARGB32 — matches BGRA8 texture format with no per-upload channel swizzle.
+    // QRhi handles the fallback swizzle if only RGBA8 is available.
+    mMapImage = std::move(argbImage);
     mMapImageInvalidated = false;
 }
 
@@ -140,8 +143,7 @@ void QCPColormapRenderer::draw(QCPPainter* painter, QCPAxis* keyAxis, QCPAxis* v
         }
     }
 
-    painter->drawImage(imageRect, mMapImage.convertToFormat(
-        QImage::Format_ARGB32_Premultiplied).flipped(flips));
+    painter->drawImage(imageRect, mMapImage.flipped(flips));
 }
 
 QCPColormapRhiLayer* QCPColormapRenderer::ensureRhiLayer()

--- a/src/painting/colormap-rhi-layer.cpp
+++ b/src/painting/colormap-rhi-layer.cpp
@@ -145,8 +145,19 @@ void QCPColormapRhiLayer::uploadResources(QRhiResourceUpdateBatch* updates,
     if (!mTexture || mTextureSize != imgSize)
     {
         delete mTexture;
-        mTexture = mRhi->newTexture(QRhiTexture::RGBA8, imgSize);
-        mTexture->create();
+        const auto fmt = mRhi->isTextureFormatSupported(QRhiTexture::BGRA8)
+            ? QRhiTexture::BGRA8
+            : QRhiTexture::RGBA8;
+        mTexture = mRhi->newTexture(fmt, imgSize);
+        if (!mTexture->create())
+        {
+            qDebug() << "Failed to create colormap RHI texture";
+            delete mTexture;
+            mTexture = nullptr;
+            delete mSrb;
+            mSrb = nullptr;
+            return;
+        }
         mTextureSize = imgSize;
         mTextureDirty = true;
         textureRecreated = true;

--- a/src/painting/paintbuffer-rhi.cpp
+++ b/src/painting/paintbuffer-rhi.cpp
@@ -90,8 +90,9 @@ void QCPPaintBufferRhi::reallocateBuffer()
 
     QSize pixelSize = mSize * mDevicePixelRatio;
 
-    // ARGB32 is QPainter's native format — avoids per-pixel channel swizzle on every draw op.
-    // QRhi converts to RGBA8 once at upload time, which is cheaper than swizzling every paint call.
+    // ARGB32_Premultiplied is QPainter's native format (BGRA byte order on little-endian).
+    // Using a BGRA8 texture avoids the per-upload CPU swizzle that RGBA8 would require.
+    // Especially important on Metal (macOS) where there's no driver-side BGRA→RGBA fast path.
     mStagingImage = QImage(pixelSize, QImage::Format_ARGB32_Premultiplied);
     mStagingImage.setDevicePixelRatio(mDevicePixelRatio);
     mStagingImage.fill(Qt::transparent);
@@ -103,7 +104,10 @@ void QCPPaintBufferRhi::reallocateBuffer()
     mTexture = nullptr;
     if (mRhi)
     {
-        mTexture = mRhi->newTexture(QRhiTexture::RGBA8, pixelSize);
+        const auto fmt = mRhi->isTextureFormatSupported(QRhiTexture::BGRA8)
+            ? QRhiTexture::BGRA8
+            : QRhiTexture::RGBA8;
+        mTexture = mRhi->newTexture(fmt, pixelSize);
         if (!mTexture->create())
         {
             qDebug() << Q_FUNC_INFO << "Failed to create RHI texture";


### PR DESCRIPTION
## Summary

- **BGRA8 textures** for paint buffers and colormap layers (with RGBA8 runtime fallback). `ARGB32_Premultiplied` staging images match BGRA8 natively — eliminates per-upload CPU byte-swizzle that Metal has no driver fast-path for.
- **Remove colormap format conversion**: `colorize()` ARGB32 output now passes directly to BGRA8 texture instead of converting to RGBA8888 first. Export path also simplified (was double-converting + flipping).
- **MSAA default changed to 1x** (was hardcoded 4x). HiDPI displays already provide sub-pixel smoothness, and 4x MSAA quadruples memory bandwidth. Users can still override via `setSampleCount()`.
- **Render loop state cleanup**: Removed redundant `setGraphicsPipeline`/`setViewport`/`setVertexInput` restoration after every colormap and plottable RHI layer draw. State is now set only before composite `drawIndexed` calls.
- **Add `create()` failure check** for colormap RHI texture.

## Test plan

- [x] All existing tests pass (`meson test`)
- [ ] Visual verification on macOS M3 (Metal backend)
- [ ] Visual verification on Linux (OpenGL/Vulkan backends)
- [ ] Verify BGRA8 fallback works if `isTextureFormatSupported(BGRA8)` returns false
- [ ] Verify colormaps render correctly (both interactive and export paths)
- [ ] Check MSAA override still works: `plot->setSampleCount(4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)