### PR TITLE
perf: cache flipped colormap image

### DIFF
--- a/src/painting/colormap-renderer.cpp
+++ b/src/painting/colormap-renderer.cpp
@@ -96,8 +96,8 @@ void QCPColormapRenderer::updateMapImage(const QCPColorMapData* data, NormalizeF
 
     // Keep native ARGB32 — matches BGRA8 texture format with no per-upload channel swizzle.
     // QRhi handles the fallback swizzle if only RGBA8 is available.
-    mMapImage = std::move(argbImage);
     mFlippedMapImage = {};
+    mMapImage = std::move(argbImage);
     mMapImageInvalidated = false;
 }
 
@@ -116,7 +116,7 @@ void QCPColormapRenderer::draw(QCPPainter* painter, QCPAxis* keyAxis, QCPAxis* v
 
     bool mirrorX = keyAxis->rangeReversed();
     bool mirrorY = valueAxis->rangeReversed();
-    Qt::Orientations flips;
+    Qt::Orientations flips {};
     if (mirrorX) flips |= Qt::Horizontal;
     if (mirrorY) flips |= Qt::Vertical;
 

--- a/src/painting/colormap-renderer.cpp
+++ b/src/painting/colormap-renderer.cpp
@@ -97,6 +97,7 @@ void QCPColormapRenderer::updateMapImage(const QCPColorMapData* data, NormalizeF
     // Keep native ARGB32 — matches BGRA8 texture format with no per-upload channel swizzle.
     // QRhi handles the fallback swizzle if only RGBA8 is available.
     mMapImage = std::move(argbImage);
+    mFlippedMapImage = {};
     mMapImageInvalidated = false;
 }
 
@@ -124,7 +125,7 @@ void QCPColormapRenderer::draw(QCPPainter* painter, QCPAxis* keyAxis, QCPAxis* v
     {
         if (auto* crl = ensureRhiLayer())
         {
-            crl->setImage(mMapImage.flipped(flips));
+            crl->setImage(flippedMapImage(flips));
             crl->setQuadRect(imageRect.normalized());
             crl->setLayer(mOwner->layer());
 
@@ -143,7 +144,17 @@ void QCPColormapRenderer::draw(QCPPainter* painter, QCPAxis* keyAxis, QCPAxis* v
         }
     }
 
-    painter->drawImage(imageRect, mMapImage.flipped(flips));
+    painter->drawImage(imageRect, flippedMapImage(flips));
+}
+
+const QImage& QCPColormapRenderer::flippedMapImage(Qt::Orientations flips)
+{
+    if (mFlippedMapImage.isNull() || flips != mLastFlips)
+    {
+        mFlippedMapImage = flips ? mMapImage.flipped(flips) : mMapImage;
+        mLastFlips = flips;
+    }
+    return mFlippedMapImage;
 }
 
 QCPColormapRhiLayer* QCPColormapRenderer::ensureRhiLayer()

--- a/src/painting/colormap-renderer.h
+++ b/src/painting/colormap-renderer.h
@@ -48,11 +48,15 @@ public:
     const QImage& mapImage() const { return mMapImage; }
 
 private:
+    const QImage& flippedMapImage(Qt::Orientations flips);
+
     QCPAbstractPlottable* mOwner;
     QCPColorGradient mGradient;
     QCPRange mDataRange;
     QCPAxis::ScaleType mDataScaleType = QCPAxis::stLinear;
     QImage mMapImage;
+    QImage mFlippedMapImage;
+    Qt::Orientations mLastFlips {};
     bool mMapImageInvalidated = true;
     QCPColorScale* mColorScale = nullptr;
     QCPColormapRhiLayer* mRhiLayer = nullptr;

--- a/tests/manual/gallery/main.cpp
+++ b/tests/manual/gallery/main.cpp
@@ -1,7 +1,10 @@
+#include <utility>
 #include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QDebug>
 #include <QDoubleSpinBox>
+#include <QFileDialog>
 #include <QGroupBox>
 #include <QLabel>
 #include <QMainWindow>
@@ -30,7 +33,28 @@ static QWidget* wrapPlot(QCustomPlot* plot)
     auto* w = new QWidget;
     auto* lay = new QVBoxLayout(w);
     lay->setContentsMargins(0, 0, 0, 0);
-    lay->addWidget(plot);
+    lay->addWidget(plot, 1);
+
+    auto* btnRow = new QHBoxLayout;
+    btnRow->addStretch();
+    for (auto [label, suffix] : {std::pair{"Export PNG", ".png"}, {"Export PDF", ".pdf"}})
+    {
+        auto* btn = new QPushButton(label, w);
+        QObject::connect(btn, &QPushButton::clicked, plot, [plot, suffix]() {
+            const bool isPdf = (QLatin1String(suffix) == QLatin1String(".pdf"));
+            QString filter = isPdf ? QStringLiteral("PDF (*.pdf)") : QStringLiteral("PNG (*.png)");
+            QString path = QFileDialog::getSaveFileName(plot, QStringLiteral("Export"),
+                                                        QStringLiteral("plot%1").arg(suffix), filter);
+            if (path.isEmpty()) return;
+            if (!path.endsWith(QLatin1String(suffix), Qt::CaseInsensitive))
+                path += QLatin1String(suffix);
+            bool ok = isPdf ? plot->savePdf(path) : plot->savePng(path, 0, 0, 2.0);
+            if (!ok) qDebug() << "Export failed:" << path;
+        });
+        btnRow->addWidget(btn);
+    }
+    lay->addLayout(btnRow);
+
     return w;
 }
 


### PR DESCRIPTION
## Summary

- **Cache flipped colormap image**: `QImage::flipped()` was called on every `draw()`, creating a full copy per frame. Now cached in `mFlippedMapImage`, recomputed only when the source image or flip orientation changes. For a 2K×2K colormap this avoids ~16MB/frame of unnecessary copying.
- **Add PNG/PDF export buttons to gallery tabs**: Every static tab now has export buttons via `wrapPlot()` for easy visual verification of the export path.

## Test plan

- [x] All existing tests pass (`meson test`)
- [x] Visual verification: colormaps render correctly with normal and reversed axes
- [x] Visual verification: PNG and PDF export produces correct output via gallery buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)