### PR TITLE
perf: cache QFontMetrics to avoid repeated construction

### DIFF
--- a/src/axis/axis.cpp
+++ b/src/axis/axis.cpp
@@ -2553,9 +2553,7 @@ int QCPAxisPainterPrivate::size()
     // degrees):
     if (!label.isEmpty())
     {
-        QFontMetrics fontMetrics(labelFont);
-        QRect bounds;
-        bounds = fontMetrics.boundingRect(
+        QRect bounds = fontMetricsFor(labelFont).boundingRect(
             0, 0, 0, 0, Qt::TextDontClip | Qt::AlignHCenter | Qt::AlignVCenter, label);
         result += bounds.height() + labelPadding;
     }
@@ -2783,7 +2781,7 @@ void QCPAxisPainterPrivate::drawTickLabel(QCPPainter* painter, double x, double 
   exponent if necessary (member substituteExponent) and calculates appropriate bounding boxes.
 */
 QCPAxisPainterPrivate::TickLabelData
-QCPAxisPainterPrivate::getTickLabelData(const QFont& font, const QString& text) const
+QCPAxisPainterPrivate::getTickLabelData(const QFont& font, const QString& text)
 {
     TickLabelData result;
 
@@ -2845,13 +2843,13 @@ QCPAxisPainterPrivate::getTickLabelData(const QFont& font, const QString& text) 
         else
             result.expFont.setPixelSize(int(result.expFont.pixelSize() * 0.75));
         // calculate bounding rects of base part(s), exponent part and total one:
-        result.baseBounds = QFontMetrics(result.baseFont)
+        result.baseBounds = fontMetricsFor(result.baseFont)
                                 .boundingRect(0, 0, 0, 0, Qt::TextDontClip, result.basePart);
-        result.expBounds = QFontMetrics(result.expFont)
+        result.expBounds = fontMetricsFor(result.expFont)
                                .boundingRect(0, 0, 0, 0, Qt::TextDontClip, result.expPart);
         if (!result.suffixPart.isEmpty())
             result.suffixBounds
-                = QFontMetrics(result.baseFont)
+                = fontMetricsFor(result.baseFont)
                       .boundingRect(0, 0, 0, 0, Qt::TextDontClip, result.suffixPart);
         result.totalBounds = result.baseBounds.adjusted(
             0, 0, result.expBounds.width() + result.suffixBounds.width() + 2,
@@ -2862,7 +2860,7 @@ QCPAxisPainterPrivate::getTickLabelData(const QFont& font, const QString& text) 
     {
         result.basePart = text;
         result.totalBounds
-            = QFontMetrics(result.baseFont)
+            = fontMetricsFor(result.baseFont)
                   .boundingRect(0, 0, 0, 0, Qt::TextDontClip | Qt::AlignHCenter, result.basePart);
     }
     result.totalBounds.moveTopLeft(
@@ -3024,7 +3022,7 @@ QPointF QCPAxisPainterPrivate::getTickLabelDrawOffset(const TickLabelData& label
   smaller width/height.
 */
 void QCPAxisPainterPrivate::getMaxTickLabelSize(const QFont& font, const QString& text,
-                                                QSize* tickLabelsSize) const
+                                                QSize* tickLabelsSize)
 {
     // note: this function must return the same tick label sizes as the placeTickLabel function.
     QSize finalSize;
@@ -3045,4 +3043,14 @@ void QCPAxisPainterPrivate::getMaxTickLabelSize(const QFont& font, const QString
         tickLabelsSize->setWidth(finalSize.width());
     if (finalSize.height() > tickLabelsSize->height())
         tickLabelsSize->setHeight(finalSize.height());
+}
+
+const QFontMetrics& QCPAxisPainterPrivate::fontMetricsFor(const QFont& font)
+{
+    if (font != mCachedMetricsFont)
+    {
+        mCachedMetricsFont = font;
+        mCachedFontMetrics = QFontMetrics(font);
+    }
+    return mCachedFontMetrics;
 }

--- a/src/axis/axis.h
+++ b/src/axis/axis.h
@@ -544,17 +544,20 @@ protected:
                                     // changed parameters
     QCache<QString, CachedLabel> mLabelCache;
     QRect mAxisSelectionBox, mTickLabelsSelectionBox, mLabelSelectionBox;
+    QFont mCachedMetricsFont;
+    QFontMetrics mCachedFontMetrics {QFont()};
 
     virtual QByteArray generateLabelParameterHash() const;
+    const QFontMetrics& fontMetricsFor(const QFont& font);
 
     virtual void placeTickLabel(QCPPainter* painter, double position, int distanceToAxis,
                                 const QString& text, QSize* tickLabelsSize);
     virtual void drawTickLabel(QCPPainter* painter, double x, double y,
                                const TickLabelData& labelData) const;
-    virtual TickLabelData getTickLabelData(const QFont& font, const QString& text) const;
+    virtual TickLabelData getTickLabelData(const QFont& font, const QString& text);
     virtual QPointF getTickLabelDrawOffset(const TickLabelData& labelData) const;
     virtual void getMaxTickLabelSize(const QFont& font, const QString& text,
-                                     QSize* tickLabelsSize) const;
+                                     QSize* tickLabelsSize);
 };
 
 #endif // QCP_AXIS_H

--- a/src/axis/labelpainter.cpp
+++ b/src/axis/labelpainter.cpp
@@ -454,7 +454,7 @@ void QCPLabelPainterPrivate::drawText(QCPPainter* painter, const QPointF& pos,
 */
 QCPLabelPainterPrivate::LabelData
 QCPLabelPainterPrivate::getTickLabelData(const QFont& font, const QColor& color, double rotation,
-                                         AnchorSide side, const QString& text) const
+                                         AnchorSide side, const QString& text)
 {
     LabelData result;
     result.rotation = rotation;
@@ -491,7 +491,7 @@ QCPLabelPainterPrivate::getTickLabelData(const QFont& font, const QColor& color,
             + 0.05); // QFontMetrics.boundingRect has a bug for exact point sizes that make the
                      // results oscillate due to internal rounding
 
-    QFontMetrics baseFontMetrics(result.baseFont);
+    const auto& baseFontMetrics = fontMetricsFor(result.baseFont);
     if (useBeautifulPowers)
     {
         // split text into parts of number/symbol that will be drawn normally and part that will be
@@ -522,11 +522,11 @@ QCPLabelPainterPrivate::getTickLabelData(const QFont& font, const QColor& color,
         // calculate bounding rects of base part(s), exponent part and total one:
         result.baseBounds
             = baseFontMetrics.boundingRect(0, 0, 0, 0, Qt::TextDontClip, result.basePart);
-        result.expBounds = QFontMetrics(result.expFont)
+        result.expBounds = fontMetricsFor(result.expFont)
                                .boundingRect(0, 0, 0, 0, Qt::TextDontClip, result.expPart);
         if (!result.suffixPart.isEmpty())
             result.suffixBounds
-                = QFontMetrics(result.baseFont)
+                = fontMetricsFor(result.baseFont)
                       .boundingRect(0, 0, 0, 0, Qt::TextDontClip, result.suffixPart);
         result.totalBounds = result.baseBounds.adjusted(
             0, 0, result.expBounds.width() + result.suffixBounds.width() + 2,
@@ -735,9 +735,19 @@ QCPLabelPainterPrivate::rotationCorrectedSide(AnchorSide side, double rotation) 
 
 void QCPLabelPainterPrivate::analyzeFontMetrics()
 {
-    const QFontMetrics fm(mFont);
+    const auto& fm = fontMetricsFor(mFont);
     mLetterCapHeight
         = fm.tightBoundingRect(QLatin1String("8"))
               .height(); // this method is slow, that's why we query it only upon font change
     mLetterDescent = fm.descent();
+}
+
+const QFontMetrics& QCPLabelPainterPrivate::fontMetricsFor(const QFont& font)
+{
+    if (font != mCachedMetricsFont)
+    {
+        mCachedMetricsFont = font;
+        mCachedFontMetrics = QFontMetrics(font);
+    }
+    return mCachedFontMetrics;
 }

--- a/src/axis/labelpainter.h
+++ b/src/axis/labelpainter.h
@@ -174,6 +174,8 @@ protected:
     QCache<QString, CachedLabel> mLabelCache;
     QRect mAxisSelectionBox, mTickLabelsSelectionBox, mLabelSelectionBox;
     int mLetterCapHeight, mLetterDescent;
+    QFont mCachedMetricsFont;
+    QFontMetrics mCachedFontMetrics {QFont()};
 
     // introduced virtual methods:
     virtual void drawLabelMaybeCached(QCPPainter* painter, const QFont& font, const QColor& color,
@@ -186,7 +188,8 @@ protected:
     QPointF getAnchorPos(const QPointF& tickPos);
     void drawText(QCPPainter* painter, const QPointF& pos, const LabelData& labelData) const;
     LabelData getTickLabelData(const QFont& font, const QColor& color, double rotation,
-                               AnchorSide side, const QString& text) const;
+                               AnchorSide side, const QString& text);
+    const QFontMetrics& fontMetricsFor(const QFont& font);
     void applyAnchorTransform(LabelData& labelData) const;
     // void getMaxTickLabelSize(const QFont &font, const QString &text, QSize *tickLabelsSize)
     // const;


### PR DESCRIPTION
## Summary

- Cache `QFontMetrics` instances in `QCPAxisPainterPrivate` and `QCPLabelPainterPrivate` instead of constructing new ones per tick label
- `QFontMetrics` construction is expensive on macOS (CoreText backend) — was being called 40+ times per replot (4 axes × ~10 ticks, twice: once for margin calculation, once for drawing)
- The cached instance is invalidated only when the font actually changes
- No behavioral change — same metrics, just computed once instead of N times

## Test plan

- [x] All existing tests pass (`meson test`)
- [x] Visual verification: tick labels render correctly on all axis types
- [ ] Profile on macOS to confirm reduced CoreText overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)