### PR TITLE
perf: skip raw draw during async pipeline, GPU polyline path, DPR-aware MSAA

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -426,9 +426,10 @@ QCustomPlot::QCustomPlot(QWidget* parent)
         , mReplotTimeAverage(0)
 {
     setAttribute(Qt::WA_NoMousePropagation);
-    // Default MSAA off — HiDPI displays already provide sub-pixel smoothness, and 4x
-    // MSAA quadruples memory bandwidth. Users can override via setSampleCount() if needed.
-    setSampleCount(1);
+    // HiDPI displays (DPR >= 2) already provide sub-pixel smoothness, so MSAA=1 saves
+    // bandwidth. Non-HiDPI gets 4x MSAA for proper antialiasing of GPU-rendered lines.
+    // Users can override via setSampleCount() after construction.
+    setSampleCount(devicePixelRatioF() >= 2.0 ? 1 : 4);
     setFocusPolicy(Qt::ClickFocus);
     setMouseTracking(true);
     QLocale currentLocale = locale();
@@ -2569,10 +2570,15 @@ void QCustomPlot::render(QRhiCommandBuffer* cb)
     if (!mRhiInitialized || !mRhi)
         return;
 
-    // Detect DPR changes
+    // Detect DPR changes (e.g. window moved between Retina and non-Retina displays)
     if (const auto newDpr = devicePixelRatioF(); !qFuzzyCompare(mBufferDevicePixelRatio, newDpr))
     {
+        // Only update MSAA if the user hasn't overridden it (still matches auto-selected value)
+        const int autoSample = mBufferDevicePixelRatio >= 2.0 ? 1 : 4;
+        const bool userOverrode = sampleCount() != autoSample;
         setBufferDevicePixelRatio(newDpr);
+        if (!userOverrode)
+            setSampleCount(newDpr >= 2.0 ? 1 : 4);
         replot(QCustomPlot::rpQueuedRefresh);
         return;
     }

--- a/src/plottables/plottable-graph2.cpp
+++ b/src/plottables/plottable-graph2.cpp
@@ -481,7 +481,7 @@ void QCPGraph2::draw(QCPPainter* painter)
     // Exception: export mode (pmNoCaching) must always draw.
     if (mNeedsResampling && !mL2Result
         && !painter->modes().testFlag(QCPPainter::pmNoCaching)
-        && (!mKeyAxis || mKeyAxis->scaleType() != QCPAxis::stLogarithmic))
+        && mKeyAxis->scaleType() != QCPAxis::stLogarithmic)
         return;
 
     // Use L2 resampled data if available, otherwise fall back to raw data.
@@ -535,11 +535,14 @@ void QCPGraph2::draw(QCPPainter* painter)
                 if (auto* prl = mParentPlot->plottableRhiLayer(mLayer))
                 {
                     const QColor penColor = mPen.color();
-                    const float penWidth = qMax(1.0f, static_cast<float>(mPen.widthF()));
+                    const double dpr = mParentPlot->bufferDevicePixelRatio();
+                    // Cosmetic pens (widthF==0) = 1 device pixel, independent of DPR
+                    const float penWidth = (mPen.isCosmetic() || qFuzzyIsNull(mPen.widthF()))
+                        ? static_cast<float>(1.0 / dpr)
+                        : qMax(1.0f, static_cast<float>(mPen.widthF()));
                     auto strokeVerts = QCPLineExtruder::extrudePolyline(pts, penWidth, penColor);
                     if (!strokeVerts.isEmpty())
                     {
-                        const double dpr = mParentPlot->bufferDevicePixelRatio();
                         const QSize outputSize = mParentPlot->rhiOutputSize();
                         prl->addPlottable({}, strokeVerts, clipRect(), dpr,
                                            outputSize.height(), rhi->isYUpInNDC());
@@ -573,6 +576,7 @@ void QCPGraph2::draw(QCPPainter* painter)
             case lsImpulse:
             {
                 auto impulse = toImpulseLines(lines, keyIsVertical);
+                applyDefaultAntialiasingHint(painter);
                 QPen impulsePen = mPen;
                 impulsePen.setCapStyle(Qt::FlatCap);
                 painter->setPen(impulsePen);

--- a/src/plottables/plottable-graph2.cpp
+++ b/src/plottables/plottable-graph2.cpp
@@ -5,7 +5,9 @@
 #include "../axis/axis.h"
 #include "../core.h"
 #include "../layoutelements/layoutelement-axisrect.h"
+#include "../painting/line-extruder.h"
 #include "../painting/painter.h"
+#include "../painting/plottable-rhi-layer.h"
 #include "../vector2d.h"
 
 QCPGraph2::QCPGraph2(QCPAxis* keyAxis, QCPAxis* valueAxis)
@@ -470,6 +472,14 @@ void QCPGraph2::draw(QCPPainter* painter)
         mL2Dirty = false;
     }
 
+    // When the async pipeline is active but hasn't delivered results yet,
+    // skip drawing raw data.  Drawing 100K+ points through QPainter is
+    // extremely slow on macOS (Core Graphics), causing multi-second stalls.
+    // The pipeline will trigger a replot when L1 is ready.
+    if (mNeedsResampling && !mL2Result
+        && !painter->modes().testFlag(QCPPainter::pmNoCaching))
+        return;
+
     // Use L2 resampled data if available, otherwise fall back to raw data.
     // Raw data is used for small datasets (below threshold), log-scale keys,
     // or while L1 is still building asynchronously.
@@ -509,35 +519,50 @@ void QCPGraph2::draw(QCPPainter* painter)
     // Draw lines
     if (mLineStyle != lsNone && mPen.style() != Qt::NoPen && mPen.color().alpha() != 0)
     {
-        applyDefaultAntialiasingHint(painter);
-        painter->setPen(mPen);
-        painter->setBrush(Qt::NoBrush);
+        // Helper: try GPU path for a polyline, fall back to QPainter
+        auto drawPoly = [&](const QVector<QPointF>& pts) {
+            if (auto* rhi = mParentPlot ? mParentPlot->rhi() : nullptr;
+                rhi && !painter->modes().testFlag(QCPPainter::pmVectorized)
+                    && mPen.style() == Qt::SolidLine)
+            {
+                if (auto* prl = mParentPlot->plottableRhiLayer(mLayer))
+                {
+                    const QColor penColor = mPen.color();
+                    const float penWidth = qMax(1.0f, static_cast<float>(mPen.widthF()));
+                    auto strokeVerts = QCPLineExtruder::extrudePolyline(pts, penWidth, penColor);
+                    if (!strokeVerts.isEmpty())
+                    {
+                        const double dpr = mParentPlot->bufferDevicePixelRatio();
+                        const QSize outputSize = mParentPlot->rhiOutputSize();
+                        prl->addPlottable({}, strokeVerts, clipRect(), dpr,
+                                           outputSize.height(), rhi->isYUpInNDC());
+                        return;
+                    }
+                }
+            }
+            // Software fallback
+            applyDefaultAntialiasingHint(painter);
+            painter->setPen(mPen);
+            painter->setBrush(Qt::NoBrush);
+            painter->drawPolyline(pts.constData(), pts.size());
+        };
 
         switch (mLineStyle)
         {
             case lsNone:
                 break;
             case lsLine:
-                painter->drawPolyline(lines.constData(), lines.size());
+                drawPoly(lines);
                 break;
             case lsStepLeft:
-            {
-                auto stepped = toStepLeftLines(lines, keyIsVertical);
-                painter->drawPolyline(stepped.constData(), stepped.size());
+                drawPoly(toStepLeftLines(lines, keyIsVertical));
                 break;
-            }
             case lsStepRight:
-            {
-                auto stepped = toStepRightLines(lines, keyIsVertical);
-                painter->drawPolyline(stepped.constData(), stepped.size());
+                drawPoly(toStepRightLines(lines, keyIsVertical));
                 break;
-            }
             case lsStepCenter:
-            {
-                auto stepped = toStepCenterLines(lines, keyIsVertical);
-                painter->drawPolyline(stepped.constData(), stepped.size());
+                drawPoly(toStepCenterLines(lines, keyIsVertical));
                 break;
-            }
             case lsImpulse:
             {
                 auto impulse = toImpulseLines(lines, keyIsVertical);

--- a/src/plottables/plottable-graph2.cpp
+++ b/src/plottables/plottable-graph2.cpp
@@ -476,8 +476,12 @@ void QCPGraph2::draw(QCPPainter* painter)
     // skip drawing raw data.  Drawing 100K+ points through QPainter is
     // extremely slow on macOS (Core Graphics), causing multi-second stalls.
     // The pipeline will trigger a replot when L1 is ready.
+    // Exception: log-scale axes never produce L2 results (rebuildL2 resets
+    // mL2Result), so we must not skip or the graph stays permanently blank.
+    // Exception: export mode (pmNoCaching) must always draw.
     if (mNeedsResampling && !mL2Result
-        && !painter->modes().testFlag(QCPPainter::pmNoCaching))
+        && !painter->modes().testFlag(QCPPainter::pmNoCaching)
+        && (!mKeyAxis || mKeyAxis->scaleType() != QCPAxis::stLogarithmic))
         return;
 
     // Use L2 resampled data if available, otherwise fall back to raw data.
@@ -519,10 +523,13 @@ void QCPGraph2::draw(QCPPainter* painter)
     // Draw lines
     if (mLineStyle != lsNone && mPen.style() != Qt::NoPen && mPen.color().alpha() != 0)
     {
-        // Helper: try GPU path for a polyline, fall back to QPainter
+        // Helper: try GPU path for a polyline, fall back to QPainter.
+        // Disabled for export: pmVectorized (SVG/PDF) and pmNoCaching (raster
+        // export via toPixmap/saveRastered) don't composite plottable RHI layers.
         auto drawPoly = [&](const QVector<QPointF>& pts) {
             if (auto* rhi = mParentPlot ? mParentPlot->rhi() : nullptr;
                 rhi && !painter->modes().testFlag(QCPPainter::pmVectorized)
+                    && !painter->modes().testFlag(QCPPainter::pmNoCaching)
                     && mPen.style() == Qt::SolidLine)
             {
                 if (auto* prl = mParentPlot->plottableRhiLayer(mLayer))

--- a/src/plottables/plottable-multigraph.cpp
+++ b/src/plottables/plottable-multigraph.cpp
@@ -5,7 +5,9 @@
 #include "../datasource/resampled-multi-datasource.h"
 #include "../layoutelements/layoutelement-axisrect.h"
 #include "../layoutelements/layoutelement-legend-group.h"
+#include "../painting/line-extruder.h"
 #include "../painting/painter.h"
+#include "../painting/plottable-rhi-layer.h"
 #include "../vector2d.h"
 #include <cmath>
 
@@ -506,6 +508,14 @@ void QCPMultiGraph::draw(QCPPainter* painter)
             rebuildL2(vp);
     }
 
+    // When the async pipeline is active but hasn't delivered results yet,
+    // skip drawing raw data.  Drawing 100K+ points through QPainter is
+    // extremely slow on macOS (Core Graphics), causing multi-second stalls.
+    // The pipeline will trigger a replot when L1 is ready.
+    if (mNeedsResampling && !mL2Result
+        && !painter->modes().testFlag(QCPPainter::pmNoCaching))
+        return;
+
     const QCPAbstractMultiDataSource* ds = mL2Result ? mL2Result.get() : mDataSource.get();
 
     int begin = ds->findBegin(mKeyAxis->range().lower);
@@ -547,16 +557,41 @@ void QCPMultiGraph::draw(QCPPainter* painter)
 
         // Draw lines
         if (mLineStyle != lsNone) {
-            applyDefaultAntialiasingHint(painter);
+            const QPen& activePen = comp.selection.isEmpty() ? comp.pen : comp.selectedPen;
             if (mLineStyle == lsImpulse) {
-                QPen impulsePen = comp.pen;
+                applyDefaultAntialiasingHint(painter);
+                QPen impulsePen = activePen;
                 impulsePen.setCapStyle(Qt::FlatCap);
-                painter->setPen(comp.selection.isEmpty() ? impulsePen : comp.selectedPen);
+                painter->setPen(impulsePen);
                 painter->drawLines(lines);
             } else {
-                painter->setPen(comp.selection.isEmpty() ? comp.pen : comp.selectedPen);
-                painter->setBrush(Qt::NoBrush);
-                painter->drawPolyline(lines.constData(), lines.size());
+                // GPU path: extrude polyline into triangle strip and render via RHI
+                bool drawnOnGpu = false;
+                if (auto* rhi = mParentPlot ? mParentPlot->rhi() : nullptr;
+                    rhi && !painter->modes().testFlag(QCPPainter::pmVectorized)
+                        && activePen.style() == Qt::SolidLine)
+                {
+                    if (auto* prl = mParentPlot->plottableRhiLayer(mLayer))
+                    {
+                        const QColor penColor = activePen.color();
+                        const float penWidth = qMax(1.0f, static_cast<float>(activePen.widthF()));
+                        auto strokeVerts = QCPLineExtruder::extrudePolyline(lines, penWidth, penColor);
+                        if (!strokeVerts.isEmpty())
+                        {
+                            const double dpr = mParentPlot->bufferDevicePixelRatio();
+                            const QSize outputSize = mParentPlot->rhiOutputSize();
+                            prl->addPlottable({}, strokeVerts, clipRect(), dpr,
+                                               outputSize.height(), rhi->isYUpInNDC());
+                            drawnOnGpu = true;
+                        }
+                    }
+                }
+                if (!drawnOnGpu) {
+                    applyDefaultAntialiasingHint(painter);
+                    painter->setPen(activePen);
+                    painter->setBrush(Qt::NoBrush);
+                    painter->drawPolyline(lines.constData(), lines.size());
+                }
             }
         }
 

--- a/src/plottables/plottable-multigraph.cpp
+++ b/src/plottables/plottable-multigraph.cpp
@@ -9,7 +9,6 @@
 #include "../painting/painter.h"
 #include "../painting/plottable-rhi-layer.h"
 #include "../vector2d.h"
-#include <cmath>
 
 static QPen defaultSelectedPen(const QPen& pen)
 {
@@ -516,7 +515,7 @@ void QCPMultiGraph::draw(QCPPainter* painter)
     // Exception: export mode (pmNoCaching) must always draw.
     if (mNeedsResampling && !mL2Result
         && !painter->modes().testFlag(QCPPainter::pmNoCaching)
-        && (!mKeyAxis || mKeyAxis->scaleType() != QCPAxis::stLogarithmic))
+        && mKeyAxis->scaleType() != QCPAxis::stLogarithmic)
         return;
 
     const QCPAbstractMultiDataSource* ds = mL2Result ? mL2Result.get() : mDataSource.get();
@@ -568,36 +567,38 @@ void QCPMultiGraph::draw(QCPPainter* painter)
                 painter->setPen(impulsePen);
                 painter->drawLines(lines);
             } else {
-                // GPU path: extrude polyline into a triangle-list vertex buffer and render via RHI.
+                // Try GPU path, fall back to QPainter.
                 // Disabled for export: pmVectorized (SVG/PDF) and pmNoCaching (raster
                 // export via toPixmap/saveRastered) don't composite plottable RHI layers.
-                bool drawnOnGpu = false;
-                if (auto* rhi = mParentPlot ? mParentPlot->rhi() : nullptr;
-                    rhi && !painter->modes().testFlag(QCPPainter::pmVectorized)
-                        && !painter->modes().testFlag(QCPPainter::pmNoCaching)
-                        && activePen.style() == Qt::SolidLine)
-                {
-                    if (auto* prl = mParentPlot->plottableRhiLayer(mLayer))
+                auto drawPoly = [&](const QVector<QPointF>& pts, const QPen& pen) {
+                    if (auto* rhi = mParentPlot ? mParentPlot->rhi() : nullptr;
+                        rhi && !painter->modes().testFlag(QCPPainter::pmVectorized)
+                            && !painter->modes().testFlag(QCPPainter::pmNoCaching)
+                            && pen.style() == Qt::SolidLine)
                     {
-                        const QColor penColor = activePen.color();
-                        const float penWidth = qMax(1.0f, static_cast<float>(activePen.widthF()));
-                        auto strokeVerts = QCPLineExtruder::extrudePolyline(lines, penWidth, penColor);
-                        if (!strokeVerts.isEmpty())
+                        if (auto* prl = mParentPlot->plottableRhiLayer(mLayer))
                         {
                             const double dpr = mParentPlot->bufferDevicePixelRatio();
-                            const QSize outputSize = mParentPlot->rhiOutputSize();
-                            prl->addPlottable({}, strokeVerts, clipRect(), dpr,
-                                               outputSize.height(), rhi->isYUpInNDC());
-                            drawnOnGpu = true;
+                            // Cosmetic pens (widthF==0) = 1 device pixel, independent of DPR
+                            const float penWidth = (pen.isCosmetic() || qFuzzyIsNull(pen.widthF()))
+                                ? static_cast<float>(1.0 / dpr)
+                                : qMax(1.0f, static_cast<float>(pen.widthF()));
+                            auto strokeVerts = QCPLineExtruder::extrudePolyline(pts, penWidth, pen.color());
+                            if (!strokeVerts.isEmpty())
+                            {
+                                const QSize outputSize = mParentPlot->rhiOutputSize();
+                                prl->addPlottable({}, strokeVerts, clipRect(), dpr,
+                                                   outputSize.height(), rhi->isYUpInNDC());
+                                return;
+                            }
                         }
                     }
-                }
-                if (!drawnOnGpu) {
                     applyDefaultAntialiasingHint(painter);
-                    painter->setPen(activePen);
+                    painter->setPen(pen);
                     painter->setBrush(Qt::NoBrush);
-                    painter->drawPolyline(lines.constData(), lines.size());
-                }
+                    painter->drawPolyline(pts.constData(), pts.size());
+                };
+                drawPoly(lines, activePen);
             }
         }
 

--- a/src/plottables/plottable-multigraph.cpp
+++ b/src/plottables/plottable-multigraph.cpp
@@ -512,8 +512,11 @@ void QCPMultiGraph::draw(QCPPainter* painter)
     // skip drawing raw data.  Drawing 100K+ points through QPainter is
     // extremely slow on macOS (Core Graphics), causing multi-second stalls.
     // The pipeline will trigger a replot when L1 is ready.
+    // Exception: log-scale axes never produce L2 results, so we must not skip.
+    // Exception: export mode (pmNoCaching) must always draw.
     if (mNeedsResampling && !mL2Result
-        && !painter->modes().testFlag(QCPPainter::pmNoCaching))
+        && !painter->modes().testFlag(QCPPainter::pmNoCaching)
+        && (!mKeyAxis || mKeyAxis->scaleType() != QCPAxis::stLogarithmic))
         return;
 
     const QCPAbstractMultiDataSource* ds = mL2Result ? mL2Result.get() : mDataSource.get();
@@ -565,10 +568,13 @@ void QCPMultiGraph::draw(QCPPainter* painter)
                 painter->setPen(impulsePen);
                 painter->drawLines(lines);
             } else {
-                // GPU path: extrude polyline into triangle strip and render via RHI
+                // GPU path: extrude polyline into a triangle-list vertex buffer and render via RHI.
+                // Disabled for export: pmVectorized (SVG/PDF) and pmNoCaching (raster
+                // export via toPixmap/saveRastered) don't composite plottable RHI layers.
                 bool drawnOnGpu = false;
                 if (auto* rhi = mParentPlot ? mParentPlot->rhi() : nullptr;
                     rhi && !painter->modes().testFlag(QCPPainter::pmVectorized)
+                        && !painter->modes().testFlag(QCPPainter::pmNoCaching)
                         && activePen.style() == Qt::SolidLine)
                 {
                     if (auto* prl = mParentPlot->plottableRhiLayer(mLayer))


### PR DESCRIPTION
## Summary

- Skip drawing raw data in `QCPGraph2::draw()` and `QCPMultiGraph::draw()` when `mNeedsResampling` is true but `mL2Result` is not yet available (async pipeline still building L1). Avoids multi-second stalls from drawing 100K+ raw points through QPainter/CoreGraphics on macOS.
- Add GPU RHI rendering path for QCPGraph2 and QCPMultiGraph polylines via `QCPLineExtruder` — extrudes solid-line strokes into triangle-list vertex buffers rendered by the plottable RHI layer. Falls back to QPainter for non-solid pens and export paths.
- Set MSAA=4 on non-HiDPI displays (DPR < 2) for proper antialiasing of GPU-rendered lines. Keep MSAA=1 on Retina where pixel density already provides smoothness. Dynamically update on DPR change.
- Fix cosmetic pen width on HiDPI: use `1.0/dpr` so GPU path matches QPainter's 1-device-pixel behavior.

## Exceptions

- Log-scale axes: skip-draw is bypassed since `rebuildL2` resets L2 for log-scale keys
- Export mode (`pmNoCaching`): always draws (skip-draw bypassed, GPU path bypassed)
- Vector export (`pmVectorized`): GPU path bypassed, uses QPainter

## Test plan

- [x] Verify large datasets render correctly after pipeline completes
- [x] Verify export (PDF/PNG) still renders complete data
- [x] Verify log-scale axes draw correctly
- [x] Build and all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)