### PR TITLE
feat: cache line data between replots for pan/zoom performance

### DIFF
--- a/src/plottables/plottable-graph2.cpp
+++ b/src/plottables/plottable-graph2.cpp
@@ -523,29 +523,84 @@ void QCPGraph2::draw(QCPPainter* painter)
     if (begin >= end)
         return;
 
-    QVector<QPointF> lines;
-    if (mAdaptiveSampling)
+    const bool keyIsVertical = mKeyAxis->orientation() == Qt::Vertical;
+
+    // --- Line caching with GPU translation ---
+    bool needFreshLines = mLineCacheDirty || mCachedLines.isEmpty();
+
+    // Check plot resize
+    QSize currentPlotSize(mKeyAxis->axisRect()->width(), mKeyAxis->axisRect()->height());
+    if (currentPlotSize != mCachedPlotSize)
+        needFreshLines = true;
+
+    // Check zoom: if axis range size changed significantly, pixel mapping is stale
+    if (!needFreshLines && mHasRenderedRange)
     {
-        lines = ds->getOptimizedLineData(
-            begin, end, static_cast<int>(mKeyAxis->axisRect()->width()),
-            mKeyAxis.data(), mValueAxis.data());
+        double keyRatio = mKeyAxis->range().size() / mRenderedRange.key.size();
+        double valRatio = mValueAxis->range().size() / mRenderedRange.value.size();
+        if (qAbs(keyRatio - 1.0) > 0.01 || qAbs(valRatio - 1.0) > 0.01)
+            needFreshLines = true;
+    }
+
+    // Check translation: if pan offset exceeds half the plot in either axis, rebuild
+    QPointF gpuOffset;
+    if (!needFreshLines && mHasRenderedRange)
+    {
+        gpuOffset = qcp::computeViewportOffset(mKeyAxis.data(), mValueAxis.data(),
+                                               mRenderedRange.key, mRenderedRange.value);
+        const double keyDim = keyIsVertical
+            ? mKeyAxis->axisRect()->height()
+            : mKeyAxis->axisRect()->width();
+        const double valDim = keyIsVertical
+            ? mKeyAxis->axisRect()->width()
+            : mKeyAxis->axisRect()->height();
+        const double keyOffset = qAbs(keyIsVertical ? gpuOffset.y() : gpuOffset.x());
+        const double valOffset = qAbs(keyIsVertical ? gpuOffset.x() : gpuOffset.y());
+        if (keyOffset > keyDim * 0.5 || valOffset > valDim * 0.5)
+            needFreshLines = true;
+    }
+
+    // Export mode always recomputes
+    if (painter->modes().testFlag(QCPPainter::pmNoCaching)
+        || painter->modes().testFlag(QCPPainter::pmVectorized))
+        needFreshLines = true;
+
+    QVector<QPointF> lines;
+    if (needFreshLines)
+    {
+        if (mAdaptiveSampling)
+        {
+            const int pixDim = keyIsVertical
+                ? static_cast<int>(mKeyAxis->axisRect()->height())
+                : static_cast<int>(mKeyAxis->axisRect()->width());
+            lines = ds->getOptimizedLineData(
+                begin, end, pixDim, mKeyAxis.data(), mValueAxis.data());
+        }
+        else
+        {
+            lines = ds->getLines(begin, end, mKeyAxis.data(), mValueAxis.data());
+        }
+
+        // Cache for reuse (but not during export)
+        if (!painter->modes().testFlag(QCPPainter::pmNoCaching)
+            && !painter->modes().testFlag(QCPPainter::pmVectorized))
+        {
+            mCachedLines = lines;
+            mRenderedRange = {mKeyAxis->range(), mValueAxis->range()};
+            mHasRenderedRange = true;
+            mLineCacheDirty = false;
+            mCachedPlotSize = currentPlotSize;
+            gpuOffset = {};
+        }
     }
     else
     {
-        lines = ds->getLines(begin, end, mKeyAxis.data(), mValueAxis.data());
+        lines = mCachedLines;
+        // gpuOffset already computed above
     }
 
     if (lines.isEmpty())
         return;
-
-    const bool keyIsVertical = mKeyAxis->orientation() == Qt::Vertical;
-
-    QPointF gpuOffset = stallPixelOffset();
-    if (!mPipeline.isBusy())
-    {
-        mRenderedRange = {mKeyAxis->range(), mValueAxis->range()};
-        mHasRenderedRange = true;
-    }
 
     // Draw lines
     if (mLineStyle != lsNone && mPen.style() != Qt::NoPen && mPen.color().alpha() != 0)

--- a/src/plottables/plottable-graph2.cpp
+++ b/src/plottables/plottable-graph2.cpp
@@ -22,11 +22,15 @@ QCPGraph2::QCPGraph2(QCPAxis* keyAxis, QCPAxis* valueAxis)
     {
         connect(keyAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged),
                 this, &QCPGraph2::onViewportChanged);
+        connect(keyAxis, &QCPAxis::scaleTypeChanged,
+                this, [this] { mLineCacheDirty = true; mCachedLines.clear(); });
     }
     if (valueAxis)
     {
         connect(valueAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged),
                 this, &QCPGraph2::onViewportChanged);
+        connect(valueAxis, &QCPAxis::scaleTypeChanged,
+                this, [this] { mLineCacheDirty = true; mCachedLines.clear(); });
     }
 
     connect(&mPipeline, &QCPGraphPipeline::finished,
@@ -63,6 +67,8 @@ void QCPGraph2::setDataSource(std::unique_ptr<QCPAbstractDataSource> source)
     mDataSource = std::move(source);
     mL1Cache.reset();
     mL2Result.reset();
+    mLineCacheDirty = true;
+    mCachedLines.clear();
     mL2Dirty = false;
     mNeedsResampling = mDataSource && mDataSource->size() >= qcp::algo::kResampleThreshold;
     if (mDataSource)
@@ -75,6 +81,8 @@ void QCPGraph2::setDataSource(std::shared_ptr<QCPAbstractDataSource> source)
     mDataSource = std::move(source);
     mL1Cache.reset();
     mL2Result.reset();
+    mLineCacheDirty = true;
+    mCachedLines.clear();
     mL2Dirty = false;
     mNeedsResampling = mDataSource && mDataSource->size() >= qcp::algo::kResampleThreshold;
     if (mDataSource)
@@ -84,6 +92,9 @@ void QCPGraph2::setDataSource(std::shared_ptr<QCPAbstractDataSource> source)
 
 void QCPGraph2::dataChanged()
 {
+    mLineCacheDirty = true;
+    mCachedLines.clear();
+
     bool wasResampling = mNeedsResampling;
     mNeedsResampling = mDataSource && mDataSource->size() >= qcp::algo::kResampleThreshold;
 

--- a/src/plottables/plottable-graph2.cpp
+++ b/src/plottables/plottable-graph2.cpp
@@ -462,7 +462,7 @@ QVector<QPointF> QCPGraph2::toImpulseLines(const QVector<QPointF>& lines, bool k
 
 QPointF QCPGraph2::stallPixelOffset() const
 {
-    if (mPipeline.isBusy() && mHasRenderedRange)
+    if (mHasRenderedRange && !mCachedLines.isEmpty())
         return qcp::computeViewportOffset(mKeyAxis.data(), mValueAxis.data(),
                                           mRenderedRange.key, mRenderedRange.value);
     return {};

--- a/src/plottables/plottable-graph2.h
+++ b/src/plottables/plottable-graph2.h
@@ -75,7 +75,12 @@ public:
 
     // Adaptive sampling control
     bool adaptiveSampling() const { return mAdaptiveSampling; }
-    void setAdaptiveSampling(bool enabled) { mAdaptiveSampling = enabled; }
+    void setAdaptiveSampling(bool enabled)
+    {
+        mAdaptiveSampling = enabled;
+        mLineCacheDirty = true;
+        mCachedLines.clear();
+    }
 
     // QCPPlottableInterface1D
     int dataCount() const override;
@@ -119,6 +124,11 @@ private:
     // GPU translation fast path: axis ranges when data was last drawn fresh
     struct { QCPRange key, value; } mRenderedRange {};
     bool mHasRenderedRange = false;
+
+    // Line cache: reuse across replots when viewport shift is small
+    QVector<QPointF> mCachedLines;
+    bool mLineCacheDirty = true;
+    QSize mCachedPlotSize;
 
     void onL1Ready();
     void rebuildL2(const ViewportParams& vp);

--- a/src/plottables/plottable-multigraph.cpp
+++ b/src/plottables/plottable-multigraph.cpp
@@ -43,6 +43,8 @@ QCPMultiGraph::QCPMultiGraph(QCPAxis* keyAxis, QCPAxis* valueAxis)
     {
         connect(keyAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged),
                 this, &QCPMultiGraph::onViewportChanged);
+        connect(keyAxis, &QCPAxis::scaleTypeChanged,
+                this, [this] { mLineCacheDirty = true; mCachedLines.clear(); });
     }
 
     connect(&mPipeline, &QCPMultiGraphPipeline::finished,
@@ -87,6 +89,8 @@ void QCPMultiGraph::setDataSource(std::shared_ptr<QCPAbstractMultiDataSource> so
     mL1Cache.reset();
     mL2Result.reset();
     mL2Dirty = false;
+    mLineCacheDirty = true;
+    mCachedLines.clear();
 
     if (mDataSource)
     {
@@ -105,6 +109,8 @@ void QCPMultiGraph::setDataSource(std::shared_ptr<QCPAbstractMultiDataSource> so
 
 void QCPMultiGraph::dataChanged()
 {
+    mLineCacheDirty = true;
+    mCachedLines.clear();
     if (mDataSource)
     {
         bool wasResampling = mNeedsResampling;
@@ -469,7 +475,7 @@ void QCPMultiGraph::deselectEvent(bool* selectionStateChanged)
 
 QPointF QCPMultiGraph::stallPixelOffset() const
 {
-    if (mPipeline.isBusy() && mHasRenderedRange)
+    if (mHasRenderedRange && !mCachedLines.isEmpty())
         return qcp::computeViewportOffset(mKeyAxis.data(), mValueAxis.data(),
                                           mRenderedRange.key, mRenderedRange.value);
     return {};
@@ -539,11 +545,65 @@ void QCPMultiGraph::draw(QCPPainter* painter)
         ? static_cast<int>(mKeyAxis->axisRect()->height())
         : static_cast<int>(mKeyAxis->axisRect()->width());
 
-    QPointF gpuOffset = stallPixelOffset();
-    if (!mPipeline.isBusy())
+    // --- Line caching with GPU translation ---
+    bool needFreshLines = mLineCacheDirty || mCachedLines.isEmpty();
+
+    QSize currentPlotSize(mKeyAxis->axisRect()->width(), mKeyAxis->axisRect()->height());
+    if (currentPlotSize != mCachedPlotSize)
+        needFreshLines = true;
+
+    if (!needFreshLines && mHasRenderedRange)
     {
-        mRenderedRange = {mKeyAxis->range(), mValueAxis->range()};
-        mHasRenderedRange = true;
+        double keyRatio = mKeyAxis->range().size() / mRenderedRange.key.size();
+        double valRatio = mValueAxis->range().size() / mRenderedRange.value.size();
+        if (qAbs(keyRatio - 1.0) > 0.01 || qAbs(valRatio - 1.0) > 0.01)
+            needFreshLines = true;
+    }
+
+    QPointF gpuOffset;
+    if (!needFreshLines && mHasRenderedRange)
+    {
+        gpuOffset = qcp::computeViewportOffset(mKeyAxis.data(), mValueAxis.data(),
+                                               mRenderedRange.key, mRenderedRange.value);
+        const double keyDim = keyIsVertical
+            ? mKeyAxis->axisRect()->height()
+            : mKeyAxis->axisRect()->width();
+        const double valDim = keyIsVertical
+            ? mKeyAxis->axisRect()->width()
+            : mKeyAxis->axisRect()->height();
+        const double keyOff = qAbs(keyIsVertical ? gpuOffset.y() : gpuOffset.x());
+        const double valOff = qAbs(keyIsVertical ? gpuOffset.x() : gpuOffset.y());
+        if (keyOff > keyDim * 0.5 || valOff > valDim * 0.5)
+            needFreshLines = true;
+    }
+
+    if (painter->modes().testFlag(QCPPainter::pmNoCaching)
+        || painter->modes().testFlag(QCPPainter::pmVectorized))
+        needFreshLines = true;
+
+    if (needFreshLines)
+    {
+        mCachedLines.resize(mComponents.size());
+        for (int c = 0; c < mComponents.size(); ++c)
+        {
+            if (!mComponents[c].visible) { mCachedLines[c].clear(); continue; }
+            if (mL2Result)
+                mCachedLines[c] = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
+            else if (mAdaptiveSampling)
+                mCachedLines[c] = ds->getOptimizedLineData(c, begin, end, pixelWidth,
+                                                           mKeyAxis.data(), mValueAxis.data());
+            else
+                mCachedLines[c] = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
+        }
+        if (!painter->modes().testFlag(QCPPainter::pmNoCaching)
+            && !painter->modes().testFlag(QCPPainter::pmVectorized))
+        {
+            mRenderedRange = {mKeyAxis->range(), mValueAxis->range()};
+            mHasRenderedRange = true;
+            mLineCacheDirty = false;
+            mCachedPlotSize = currentPlotSize;
+            gpuOffset = {};
+        }
     }
 
     for (int c = 0; c < mComponents.size(); ++c) {
@@ -551,15 +611,8 @@ void QCPMultiGraph::draw(QCPPainter* painter)
         if (!comp.visible) continue;
         if (mLineStyle == lsNone && comp.scatterStyle.isNone()) continue;
 
-        QVector<QPointF> lines;
-        if (mL2Result)
-            lines = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
-        else if (mAdaptiveSampling)
-            lines = ds->getOptimizedLineData(c, begin, end, pixelWidth,
-                                              mKeyAxis.data(), mValueAxis.data());
-        else
-            lines = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
-
+        const QVector<QPointF>& cachedForComp = (c < mCachedLines.size()) ? mCachedLines[c] : QVector<QPointF>();
+        QVector<QPointF> lines = cachedForComp;
         if (lines.isEmpty()) continue;
 
         // Apply line style transform

--- a/src/plottables/plottable-multigraph.cpp
+++ b/src/plottables/plottable-multigraph.cpp
@@ -46,6 +46,11 @@ QCPMultiGraph::QCPMultiGraph(QCPAxis* keyAxis, QCPAxis* valueAxis)
         connect(keyAxis, &QCPAxis::scaleTypeChanged,
                 this, [this] { mLineCacheDirty = true; mCachedLines.clear(); });
     }
+    if (valueAxis)
+    {
+        connect(valueAxis, &QCPAxis::scaleTypeChanged,
+                this, [this] { mLineCacheDirty = true; mCachedLines.clear(); });
+    }
 
     connect(&mPipeline, &QCPMultiGraphPipeline::finished,
             this, [this](uint64_t) { onL1Ready(); });
@@ -577,26 +582,29 @@ void QCPMultiGraph::draw(QCPPainter* painter)
             needFreshLines = true;
     }
 
-    if (painter->modes().testFlag(QCPPainter::pmNoCaching)
-        || painter->modes().testFlag(QCPPainter::pmVectorized))
+    const bool isExportMode = painter->modes().testFlag(QCPPainter::pmNoCaching)
+                           || painter->modes().testFlag(QCPPainter::pmVectorized);
+    if (isExportMode)
         needFreshLines = true;
+
+    QVector<QVector<QPointF>> exportLines;
+    auto& linesTarget = isExportMode ? exportLines : mCachedLines;
 
     if (needFreshLines)
     {
-        mCachedLines.resize(mComponents.size());
+        linesTarget.resize(mComponents.size());
         for (int c = 0; c < mComponents.size(); ++c)
         {
-            if (!mComponents[c].visible) { mCachedLines[c].clear(); continue; }
+            if (!mComponents[c].visible) { linesTarget[c].clear(); continue; }
             if (mL2Result)
-                mCachedLines[c] = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
+                linesTarget[c] = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
             else if (mAdaptiveSampling)
-                mCachedLines[c] = ds->getOptimizedLineData(c, begin, end, pixelWidth,
+                linesTarget[c] = ds->getOptimizedLineData(c, begin, end, pixelWidth,
                                                            mKeyAxis.data(), mValueAxis.data());
             else
-                mCachedLines[c] = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
+                linesTarget[c] = ds->getLines(c, begin, end, mKeyAxis.data(), mValueAxis.data());
         }
-        if (!painter->modes().testFlag(QCPPainter::pmNoCaching)
-            && !painter->modes().testFlag(QCPPainter::pmVectorized))
+        if (!isExportMode)
         {
             mRenderedRange = {mKeyAxis->range(), mValueAxis->range()};
             mHasRenderedRange = true;
@@ -611,8 +619,8 @@ void QCPMultiGraph::draw(QCPPainter* painter)
         if (!comp.visible) continue;
         if (mLineStyle == lsNone && comp.scatterStyle.isNone()) continue;
 
-        const QVector<QPointF>& cachedForComp = (c < mCachedLines.size()) ? mCachedLines[c] : QVector<QPointF>();
-        QVector<QPointF> lines = cachedForComp;
+        if (c >= linesTarget.size()) continue;
+        QVector<QPointF> lines = linesTarget[c];
         if (lines.isEmpty()) continue;
 
         // Apply line style transform

--- a/src/plottables/plottable-multigraph.h
+++ b/src/plottables/plottable-multigraph.h
@@ -71,7 +71,7 @@ public:
     LineStyle lineStyle() const { return mLineStyle; }
     void setLineStyle(LineStyle style) { mLineStyle = style; }
     bool adaptiveSampling() const { return mAdaptiveSampling; }
-    void setAdaptiveSampling(bool enabled) { mAdaptiveSampling = enabled; }
+    void setAdaptiveSampling(bool enabled) { if (mAdaptiveSampling != enabled) { mAdaptiveSampling = enabled; mLineCacheDirty = true; mCachedLines.clear(); } }
     int scatterSkip() const { return mScatterSkip; }
     void setScatterSkip(int skip) { mScatterSkip = qMax(0, skip); }
 

--- a/src/plottables/plottable-multigraph.h
+++ b/src/plottables/plottable-multigraph.h
@@ -132,6 +132,10 @@ protected:
     bool mNeedsResampling = false;
     struct { QCPRange key, value; } mRenderedRange {};
     bool mHasRenderedRange = false;
+    // Line cache: per-component cached lines, reused with GPU offset
+    QVector<QVector<QPointF>> mCachedLines;
+    bool mLineCacheDirty = true;
+    QSize mCachedPlotSize;
 
     void onL1Ready();
     void rebuildL2(const ViewportParams& vp);

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1653,4 +1653,30 @@ void TestPipeline::graph2LineCacheInvalidatedOnDataChange()
 
 void TestPipeline::multiGraphLineCacheReusedOnSmallPan()
 {
+    auto* mg = new QCPMultiGraph(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10000;
+    const int cols = 3;
+    std::vector<double> keys(N);
+    std::vector<std::vector<double>> values(cols, std::vector<double>(N));
+    for (int i = 0; i < N; ++i) {
+        keys[i] = i;
+        for (int c = 0; c < cols; ++c)
+            values[c][i] = std::sin(i * 0.01 + c);
+    }
+    mg->setDataSource(std::make_shared<QCPSoAMultiDataSource<
+        std::vector<double>, std::vector<double>>>(
+        std::move(keys), std::move(values)));
+    mPlot->xAxis->setRange(0, N);
+    mPlot->yAxis->setRange(-1.5, 1.5);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    QVERIFY(!mg->mCachedLines.isEmpty());
+    auto cachedBefore = mg->mCachedLines;
+
+    // Small pan
+    double shift = N * 0.05;
+    mPlot->xAxis->setRange(shift, N + shift);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    QCOMPARE(mg->mCachedLines, cachedBefore);
 }

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1583,14 +1583,72 @@ void TestPipeline::graph2LineCacheReusedOnSmallPan()
 
 void TestPipeline::graph2LineCacheRebuiltOnLargePan()
 {
+    auto* graph = new QCPGraph2(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10000;
+    std::vector<double> keys(N), values(N);
+    for (int i = 0; i < N; ++i) { keys[i] = i; values[i] = std::sin(i * 0.01); }
+    graph->setDataSource(std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::vector<double>(keys), std::vector<double>(values)));
+    mPlot->xAxis->setRange(0, N);
+    mPlot->yAxis->setRange(-1.5, 1.5);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    auto cachedBefore = graph->mCachedLines;
+    QVERIFY(!cachedBefore.isEmpty());
+
+    // Large pan: shift by 60% — should trigger rebuild
+    double shift = N * 0.6;
+    mPlot->xAxis->setRange(shift, N + shift);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    // Cache should have been rebuilt (different data)
+    QVERIFY(graph->mCachedLines != cachedBefore);
 }
 
 void TestPipeline::graph2LineCacheRebuiltOnZoom()
 {
+    auto* graph = new QCPGraph2(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10000;
+    std::vector<double> keys(N), values(N);
+    for (int i = 0; i < N; ++i) { keys[i] = i; values[i] = std::sin(i * 0.01); }
+    graph->setDataSource(std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::vector<double>(keys), std::vector<double>(values)));
+    mPlot->xAxis->setRange(0, N);
+    mPlot->yAxis->setRange(-1.5, 1.5);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    auto cachedBefore = graph->mCachedLines;
+    QVERIFY(!cachedBefore.isEmpty());
+
+    // Zoom in 2x (center stays same, range halved) — should trigger rebuild
+    mPlot->xAxis->setRange(N * 0.25, N * 0.75);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    QVERIFY(graph->mCachedLines != cachedBefore);
 }
 
 void TestPipeline::graph2LineCacheInvalidatedOnDataChange()
 {
+    auto* graph = new QCPGraph2(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10000;
+    std::vector<double> keys(N), values(N);
+    for (int i = 0; i < N; ++i) { keys[i] = i; values[i] = std::sin(i * 0.01); }
+    graph->setDataSource(std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::vector<double>(keys), std::vector<double>(values)));
+    mPlot->xAxis->setRange(0, N);
+    mPlot->yAxis->setRange(-1.5, 1.5);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    QVERIFY(!graph->mCachedLines.isEmpty());
+
+    // Replace data — cache must be invalidated
+    std::vector<double> keys2(N), values2(N);
+    for (int i = 0; i < N; ++i) { keys2[i] = i; values2[i] = std::cos(i * 0.01); }
+    graph->setDataSource(std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::move(keys2), std::move(values2)));
+
+    QVERIFY(graph->mCachedLines.isEmpty());
+    QVERIFY(graph->mLineCacheDirty);
 }
 
 void TestPipeline::multiGraphLineCacheReusedOnSmallPan()

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1555,3 +1555,44 @@ void TestPipeline::multiGraphHiddenComponentsStillResampled()
     // Draw with one hidden component — should not crash
     mPlot->replot(QCustomPlot::rpImmediateRefresh);
 }
+
+void TestPipeline::graph2LineCacheReusedOnSmallPan()
+{
+    auto* graph = new QCPGraph2(mPlot->xAxis, mPlot->yAxis);
+    const int N = 10000;
+    std::vector<double> keys(N), values(N);
+    for (int i = 0; i < N; ++i) { keys[i] = i; values[i] = std::sin(i * 0.01); }
+    graph->setDataSource(std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::vector<double>(keys), std::vector<double>(values)));
+    mPlot->xAxis->setRange(0, N);
+    mPlot->yAxis->setRange(-1.5, 1.5);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    // Cache should be populated
+    QVERIFY(!graph->mCachedLines.isEmpty());
+    auto cachedBefore = graph->mCachedLines;
+
+    // Small pan: shift by 5% of range — should reuse cache
+    double shift = N * 0.05;
+    mPlot->xAxis->setRange(shift, N + shift);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    // Cache should NOT have been rebuilt (same data)
+    QCOMPARE(graph->mCachedLines, cachedBefore);
+}
+
+void TestPipeline::graph2LineCacheRebuiltOnLargePan()
+{
+}
+
+void TestPipeline::graph2LineCacheRebuiltOnZoom()
+{
+}
+
+void TestPipeline::graph2LineCacheInvalidatedOnDataChange()
+{
+}
+
+void TestPipeline::multiGraphLineCacheReusedOnSmallPan()
+{
+}

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -105,6 +105,13 @@ private slots:
     void viewportOffsetLogScale();
     void viewportOffsetNoChange();
 
+    // Line caching
+    void graph2LineCacheReusedOnSmallPan();
+    void graph2LineCacheRebuiltOnLargePan();
+    void graph2LineCacheRebuiltOnZoom();
+    void graph2LineCacheInvalidatedOnDataChange();
+    void multiGraphLineCacheReusedOnSmallPan();
+
     // GPU translation fast path
     void graph2TranslationOffsetWhenBusy();
     void graph2TranslationResetsOnFreshData();


### PR DESCRIPTION
## Summary

- Cache pixel-space line data (`QVector<QPointF>`) in QCPGraph2 and QCPMultiGraph between replots
- Reuse cached lines with GPU translation offset during small pans, avoiding O(n) `getOptimizedLineData`/`getLines` on every frame
- Rebuild cache when translation exceeds 50% of plot dimension, zoom changes >1%, data changes, scale type changes, or plot resizes
- Extend `stallPixelOffset()` to work unconditionally (not just when async pipeline is busy), enabling GPU translation for all dataset sizes
- Fix pre-existing bug: `getOptimizedLineData` in QCPGraph2 now uses correct pixel dimension for vertical key axes

## Motivation

Datasets in the 100K–10M range (below the async resampling threshold) hit raw `getOptimizedLineData` on every replot during pan/zoom. This is O(n) per frame per component. With caching, repeated replots during panning become O(1) — the cached lines are reused and the GPU applies a pixel offset.

## Test plan

- [x] `graph2LineCacheReusedOnSmallPan` — 5% pan reuses cache
- [x] `graph2LineCacheRebuiltOnLargePan` — 60% pan triggers rebuild
- [x] `graph2LineCacheRebuiltOnZoom` — 2x zoom triggers rebuild
- [x] `graph2LineCacheInvalidatedOnDataChange` — setDataSource clears cache
- [x] `multiGraphLineCacheReusedOnSmallPan` — multi-component cache reuse
- [x] All existing GPU translation tests pass (`stallPixelOffsetIdleIsZero`, `stallPixelOffsetGraph2Busy`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)