### PR TITLE
fix(Profiling): guard PROFILE_* macros with #ifndef

### DIFF
--- a/src/Profiling.hpp
+++ b/src/Profiling.hpp
@@ -21,27 +21,57 @@
 ----------------------------------------------------------------------------*/
 #pragma once
 
+// Macros are guarded with #ifndef so that consumers (e.g. SciQLopPlots) can
+// provide their own definitions without colliding when both headers end up in
+// the same translation unit via transitive includes.
 #ifdef TRACY_ENABLE
 
 #include <tracy/Tracy.hpp>
 
-#define PROFILE_FRAME_MARK FrameMark
-#define PROFILE_HERE ZoneScoped
-#define PROFILE_HERE_N(name) ZoneScopedN(name)
-#define PROFILE_HERE_NC(name, color) ZoneScopedNC(name, color)
-#define PROFILE_PASS_VALUE(value) ZoneValue(value)
-#define PROFILE_PASS_TXT(txt, size) ZoneText(txt, size)
-#define PROFILE_PASS_VALUE_N(name, value) ZoneValue(value)
-
+#ifndef PROFILE_FRAME_MARK
+#  define PROFILE_FRAME_MARK FrameMark
+#endif
+#ifndef PROFILE_HERE
+#  define PROFILE_HERE ZoneScoped
+#endif
+#ifndef PROFILE_HERE_N
+#  define PROFILE_HERE_N(name) ZoneScopedN(name)
+#endif
+#ifndef PROFILE_HERE_NC
+#  define PROFILE_HERE_NC(name, color) ZoneScopedNC(name, color)
+#endif
+#ifndef PROFILE_PASS_VALUE
+#  define PROFILE_PASS_VALUE(value) ZoneValue(value)
+#endif
+#ifndef PROFILE_PASS_TXT
+#  define PROFILE_PASS_TXT(txt, size) ZoneText(txt, size)
+#endif
+#ifndef PROFILE_PASS_VALUE_N
+#  define PROFILE_PASS_VALUE_N(name, value) ZoneValue(value)
+#endif
 
 #else
 
-#define PROFILE_FRAME_MARK
-#define PROFILE_HERE
-#define PROFILE_HERE_N(name)
-#define PROFILE_HERE_NC(name, color)
-#define PROFILE_PASS_VALUE(value)
-#define PROFILE_PASS_VALUE_N(name, value)
-#define PROFILE_PASS_TXT(txt, size)
+#ifndef PROFILE_FRAME_MARK
+#  define PROFILE_FRAME_MARK
+#endif
+#ifndef PROFILE_HERE
+#  define PROFILE_HERE
+#endif
+#ifndef PROFILE_HERE_N
+#  define PROFILE_HERE_N(name)
+#endif
+#ifndef PROFILE_HERE_NC
+#  define PROFILE_HERE_NC(name, color)
+#endif
+#ifndef PROFILE_PASS_VALUE
+#  define PROFILE_PASS_VALUE(value)
+#endif
+#ifndef PROFILE_PASS_VALUE_N
+#  define PROFILE_PASS_VALUE_N(name, value)
+#endif
+#ifndef PROFILE_PASS_TXT
+#  define PROFILE_PASS_TXT(txt, size)
+#endif
 
 #endif


### PR DESCRIPTION
## Summary
Guards every `#define PROFILE_*` in `src/Profiling.hpp` with `#ifndef`. Allows downstream consumers (e.g. SciQLopPlots) to provide their own macro definitions targeting a different backend without silent collisions when both headers end up in the same translation unit via transitive includes (NeoQCP gets pulled in via `qcustomplot.h` / `<datasource/...>`).

## Why
SciQLopPlots is adding a runtime Chrome JSON / Perfetto tracer (https://github.com/SciQLop/SciQLopPlots/pull/55) and unifies its `PROFILE_HERE_N` to feed both that tracer and Tracy. Without these guards, NeoQCP's plain `#define` redefinitions silently override the SciQLopPlots versions in TUs that include both headers, dropping the new tracer at those sites.

## Behavior
- NeoQCP-only TUs: unchanged. No consumer has predefined the macros, so the `#ifndef` always falls through to the same definition.
- Consumer + NeoQCP TUs: consumer's definition wins, regardless of include order.
- Either branch (`TRACY_ENABLE` on or off) is guarded the same way.

## Test plan
- [x] NeoQCP compiles with `tracy_enable=on` and `tracy_enable=off`
- [x] SciQLopPlots PR #55 builds clean (no `redefined` warnings) with this patch in place
- [x] SciQLopPlots `tracing_engine` + `tracing_python` tests pass

Generated with [Claude Code](https://claude.com/claude-code)
