### PR TITLE
fix(histogram2d): correct unsorted/NaN bin range + per-axis log binning

### DIFF
--- a/src/datasource/abstract-datasource.h
+++ b/src/datasource/abstract-datasource.h
@@ -40,10 +40,13 @@ public:
     //
     // Unlike keyRange()/valueRange(), this makes NO sorted-key assumption and a
     // sample contributes only when BOTH coordinates are finite -- so the bounds
-    // match exactly the set of points a histogram will accumulate. Returns false
-    // when no finite pair exists. Default scans via keyAt()/valueAt(); typed
-    // sources override for a non-virtual inner loop.
-    virtual bool finiteKeyValueBounds(QCPRange& keyOut, QCPRange& valueOut) const
+    // match exactly the set of points a histogram will accumulate. With
+    // keyPositiveOnly/valuePositiveOnly set (log binning), that coordinate must
+    // also be > 0. Returns false when no qualifying pair exists. Default scans
+    // via keyAt()/valueAt(); typed sources override for a non-virtual inner loop.
+    virtual bool finiteKeyValueBounds(QCPRange& keyOut, QCPRange& valueOut,
+                                      bool keyPositiveOnly = false,
+                                      bool valuePositiveOnly = false) const
     {
         double kLo = std::numeric_limits<double>::infinity(), kHi = -kLo;
         double vLo = kLo, vHi = -kLo;
@@ -54,6 +57,8 @@ public:
             const double k = keyAt(i);
             const double v = valueAt(i);
             if (!std::isfinite(k) || !std::isfinite(v))
+                continue;
+            if ((keyPositiveOnly && k <= 0) || (valuePositiveOnly && v <= 0))
                 continue;
             kLo = std::min(kLo, k); kHi = std::max(kHi, k);
             vLo = std::min(vLo, v); vHi = std::max(vHi, v);

--- a/src/datasource/abstract-datasource.h
+++ b/src/datasource/abstract-datasource.h
@@ -3,6 +3,9 @@
 #include "axis/range.h"
 #include <QPointF>
 #include <QVector>
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <ranges>
 #include <type_traits>
 
@@ -32,6 +35,36 @@ public:
     virtual QCPRange valueRange(bool& foundRange,
                                 QCP::SignDomain sd = QCP::sdBoth,
                                 const QCPRange& inKeyRange = QCPRange()) const = 0;
+
+    // Finite, pairwise bounds over (key, value) samples, for 2D binning.
+    //
+    // Unlike keyRange()/valueRange(), this makes NO sorted-key assumption and a
+    // sample contributes only when BOTH coordinates are finite -- so the bounds
+    // match exactly the set of points a histogram will accumulate. Returns false
+    // when no finite pair exists. Default scans via keyAt()/valueAt(); typed
+    // sources override for a non-virtual inner loop.
+    virtual bool finiteKeyValueBounds(QCPRange& keyOut, QCPRange& valueOut) const
+    {
+        double kLo = std::numeric_limits<double>::infinity(), kHi = -kLo;
+        double vLo = kLo, vHi = -kLo;
+        bool any = false;
+        const int n = size();
+        for (int i = 0; i < n; ++i)
+        {
+            const double k = keyAt(i);
+            const double v = valueAt(i);
+            if (!std::isfinite(k) || !std::isfinite(v))
+                continue;
+            kLo = std::min(kLo, k); kHi = std::max(kHi, k);
+            vLo = std::min(vLo, v); vHi = std::max(vHi, v);
+            any = true;
+        }
+        if (!any)
+            return false;
+        keyOut = QCPRange(kLo, kHi);
+        valueOut = QCPRange(vLo, vHi);
+        return true;
+    }
 
     // Binary search on sorted keys.
     // expandedRange=true includes one extra point beyond the boundary

--- a/src/datasource/histogram-binner.h
+++ b/src/datasource/histogram-binner.h
@@ -12,10 +12,11 @@ inline QCPColorMapData* bin2d(const QCPAbstractDataSource& src, int keyBins, int
     if (n == 0 || keyBins <= 0 || valueBins <= 0)
         return nullptr;
 
-    bool foundKey = false, foundVal = false;
-    QCPRange keyRange = src.keyRange(foundKey);
-    QCPRange valRange = src.valueRange(foundVal);
-    if (!foundKey || !foundVal)
+    // Histogram input is scattered, not sorted by key, and may contain NaN/Inf.
+    // finiteKeyValueBounds() gives the true min/max over finite (key, value)
+    // pairs -- never the first/last sample. No finite pair => no histogram.
+    QCPRange keyRange, valRange;
+    if (!src.finiteKeyValueBounds(keyRange, valRange))
         return nullptr;
 
     if (keyRange.size() == 0) { keyRange.lower -= 0.5; keyRange.upper += 0.5; }

--- a/src/datasource/histogram-binner.h
+++ b/src/datasource/histogram-binner.h
@@ -6,7 +6,51 @@
 
 namespace qcp::algo {
 
-inline QCPColorMapData* bin2d(const QCPAbstractDataSource& src, int keyBins, int valueBins)
+// Maps a coordinate to a bin index, evenly spaced in linear or log10 space.
+// For log, callers must have already excluded non-positive coordinates.
+struct BinAxis
+{
+    double lo;       // lower edge in mapped space (coord, or log10(coord))
+    double invWidth; // bins / span, in mapped space
+    int bins;
+    bool log;
+
+    static BinAxis make(const QCPRange& range, int bins, bool log)
+    {
+        const double lo = log ? std::log10(range.lower) : range.lower;
+        const double hi = log ? std::log10(range.upper) : range.upper;
+        const double span = hi - lo;
+        return BinAxis { lo, span > 0 ? bins / span : 0.0, bins, log };
+    }
+
+    int index(double x) const
+    {
+        const double pos = log ? std::log10(x) : x;
+        return std::clamp(static_cast<int>((pos - lo) * invWidth), 0, bins - 1);
+    }
+};
+
+// Widen a zero-width range so binning has a non-degenerate span. Log ranges
+// (lower > 0, guaranteed by the positive-only bounds) widen multiplicatively.
+inline void expandIfFlat(QCPRange& range, bool log)
+{
+    if (range.size() != 0)
+        return;
+    if (log && range.lower > 0)
+    {
+        const double f = std::sqrt(10.0);
+        range.lower /= f;
+        range.upper *= f;
+    }
+    else
+    {
+        range.lower -= 0.5;
+        range.upper += 0.5;
+    }
+}
+
+inline QCPColorMapData* bin2d(const QCPAbstractDataSource& src, int keyBins, int valueBins,
+                              bool keyLog = false, bool valueLog = false)
 {
     const int n = src.size();
     if (n == 0 || keyBins <= 0 || valueBins <= 0)
@@ -14,19 +58,24 @@ inline QCPColorMapData* bin2d(const QCPAbstractDataSource& src, int keyBins, int
 
     // Histogram input is scattered, not sorted by key, and may contain NaN/Inf.
     // finiteKeyValueBounds() gives the true min/max over finite (key, value)
-    // pairs -- never the first/last sample. No finite pair => no histogram.
+    // pairs -- never the first/last sample. On a log axis, non-positive samples
+    // can't be placed, so they are excluded from the bounds too. No qualifying
+    // pair => no histogram.
     QCPRange keyRange, valRange;
-    if (!src.finiteKeyValueBounds(keyRange, valRange))
+    if (!src.finiteKeyValueBounds(keyRange, valRange, keyLog, valueLog))
         return nullptr;
 
-    if (keyRange.size() == 0) { keyRange.lower -= 0.5; keyRange.upper += 0.5; }
-    if (valRange.size() == 0) { valRange.lower -= 0.5; valRange.upper += 0.5; }
+    expandIfFlat(keyRange, keyLog);
+    expandIfFlat(valRange, valueLog);
 
     auto* data = new QCPColorMapData(keyBins, valueBins, keyRange, valRange);
     data->fill(0);
 
-    const double kBinWidth = keyRange.size() / keyBins;
-    const double vBinWidth = valRange.size() / valueBins;
+    // Bins are evenly spaced in log space when requested, so the grid's linear
+    // coordinate extent [min, max] is preserved (the renderer stretches cells
+    // uniformly in pixels, which on a log axis is uniform in log).
+    const BinAxis kAxis = BinAxis::make(keyRange, keyBins, keyLog);
+    const BinAxis vAxis = BinAxis::make(valRange, valueBins, valueLog);
 
     for (int i = 0; i < n; ++i)
     {
@@ -34,9 +83,11 @@ inline QCPColorMapData* bin2d(const QCPAbstractDataSource& src, int keyBins, int
         double v = src.valueAt(i);
         if (!std::isfinite(k) || !std::isfinite(v))
             continue;
+        if ((keyLog && k <= 0) || (valueLog && v <= 0))
+            continue;
 
-        int kb = std::clamp(static_cast<int>((k - keyRange.lower) / kBinWidth), 0, keyBins - 1);
-        int vb = std::clamp(static_cast<int>((v - valRange.lower) / vBinWidth), 0, valueBins - 1);
+        const int kb = kAxis.index(k);
+        const int vb = vAxis.index(v);
         data->setCell(kb, vb, data->cell(kb, vb) + 1.0);
     }
 

--- a/src/datasource/histogram-binner.h
+++ b/src/datasource/histogram-binner.h
@@ -17,6 +17,11 @@ struct BinAxis
 
     static BinAxis make(const QCPRange& range, int bins, bool log)
     {
+        // Log bins require a positive range; callers (bin2d via the positive-only
+        // finiteKeyValueBounds + expandIfFlat) must guarantee it. Asserting here
+        // keeps that non-local invariant honest and catches a future regression
+        // before it turns into log10(<=0) -> NaN -> UB in the index cast.
+        Q_ASSERT(!log || (range.lower > 0 && range.upper > 0));
         const double lo = log ? std::log10(range.lower) : range.lower;
         const double hi = log ? std::log10(range.upper) : range.upper;
         const double span = hi - lo;

--- a/src/datasource/soa-datasource.h
+++ b/src/datasource/soa-datasource.h
@@ -52,7 +52,9 @@ public:
         return qcp::algo::valueRange(mKeys, mValues, foundRange, sd, inKeyRange);
     }
 
-    bool finiteKeyValueBounds(QCPRange& keyOut, QCPRange& valueOut) const override
+    bool finiteKeyValueBounds(QCPRange& keyOut, QCPRange& valueOut,
+                              bool keyPositiveOnly = false,
+                              bool valuePositiveOnly = false) const override
     {
         PROFILE_HERE_N("SoA::finiteKeyValueBounds");
         const int n = static_cast<int>(std::ranges::size(mKeys));
@@ -64,6 +66,8 @@ public:
             const double k = static_cast<double>(mKeys[i]);
             const double v = static_cast<double>(mValues[i]);
             if (!std::isfinite(k) || !std::isfinite(v))
+                continue;
+            if ((keyPositiveOnly && k <= 0) || (valuePositiveOnly && v <= 0))
                 continue;
             kLo = std::min(kLo, k); kHi = std::max(kHi, k);
             vLo = std::min(vLo, v); vHi = std::max(vHi, v);

--- a/src/datasource/soa-datasource.h
+++ b/src/datasource/soa-datasource.h
@@ -52,6 +52,30 @@ public:
         return qcp::algo::valueRange(mKeys, mValues, foundRange, sd, inKeyRange);
     }
 
+    bool finiteKeyValueBounds(QCPRange& keyOut, QCPRange& valueOut) const override
+    {
+        PROFILE_HERE_N("SoA::finiteKeyValueBounds");
+        const int n = static_cast<int>(std::ranges::size(mKeys));
+        double kLo = std::numeric_limits<double>::infinity(), kHi = -kLo;
+        double vLo = kLo, vHi = -kLo;
+        bool any = false;
+        for (int i = 0; i < n; ++i)
+        {
+            const double k = static_cast<double>(mKeys[i]);
+            const double v = static_cast<double>(mValues[i]);
+            if (!std::isfinite(k) || !std::isfinite(v))
+                continue;
+            kLo = std::min(kLo, k); kHi = std::max(kHi, k);
+            vLo = std::min(vLo, v); vHi = std::max(vHi, v);
+            any = true;
+        }
+        if (!any)
+            return false;
+        keyOut = QCPRange(kLo, kHi);
+        valueOut = QCPRange(vLo, vHi);
+        return true;
+    }
+
     int findBegin(double sortKey, bool expandedRange = true) const override
     {
         return qcp::algo::findBegin(mKeys, sortKey, expandedRange);

--- a/src/plottables/plottable-histogram2d.cpp
+++ b/src/plottables/plottable-histogram2d.cpp
@@ -35,13 +35,16 @@ void QCPHistogram2D::installTransform()
 {
     int capturedKeyBins = mKeyBins;
     int capturedValueBins = mValueBins;
+    const bool keyLog = mKeyBinScale == QCPAxis::stLogarithmic;
+    const bool valueLog = mValueBinScale == QCPAxis::stLogarithmic;
 
     mPipeline.setTransform(TransformKind::ViewportIndependent,
-        [capturedKeyBins, capturedValueBins](
+        [capturedKeyBins, capturedValueBins, keyLog, valueLog](
             const QCPAbstractDataSource& src,
             const ViewportParams& /*vp*/,
             std::any& /*cache*/) -> std::shared_ptr<QCPColorMapData> {
-            auto* raw = qcp::algo::bin2d(src, capturedKeyBins, capturedValueBins);
+            auto* raw = qcp::algo::bin2d(src, capturedKeyBins, capturedValueBins,
+                                         keyLog, valueLog);
             return std::shared_ptr<QCPColorMapData>(raw);
         });
 }
@@ -70,6 +73,24 @@ void QCPHistogram2D::setBins(int keyBins, int valueBins)
         return;
     mKeyBins = keyBins;
     mValueBins = valueBins;
+    installTransform();
+    mPipeline.onDataChanged();
+}
+
+void QCPHistogram2D::setKeyBinScale(QCPAxis::ScaleType type)
+{
+    if (mKeyBinScale == type)
+        return;
+    mKeyBinScale = type;
+    installTransform();
+    mPipeline.onDataChanged();
+}
+
+void QCPHistogram2D::setValueBinScale(QCPAxis::ScaleType type)
+{
+    if (mValueBinScale == type)
+        return;
+    mValueBinScale = type;
     installTransform();
     mPipeline.onDataChanged();
 }

--- a/src/plottables/plottable-histogram2d.cpp
+++ b/src/plottables/plottable-histogram2d.cpp
@@ -306,7 +306,13 @@ QCPRange QCPHistogram2D::getKeyRange(bool& foundRange, QCP::SignDomain inSignDom
         foundRange = false;
         return {};
     }
-    return mDataSource->keyRange(foundRange, inSignDomain);
+    // Histogram keys are scattered, not sorted, so keyRange()'s first/last
+    // shortcut would be wrong. Report the true finite min/max (positive-only on
+    // a log axis), matching what bin2d() accumulates.
+    QCPRange kr, vr;
+    foundRange = mDataSource->finiteKeyValueBounds(
+        kr, vr, inSignDomain == QCP::sdPositive, false);
+    return foundRange ? kr : QCPRange();
 }
 
 QCPRange QCPHistogram2D::getValueRange(bool& foundRange, QCP::SignDomain inSignDomain,
@@ -330,11 +336,9 @@ double QCPHistogram2D::selectTest(const QPointF& pos, bool onlySelectable, QVari
     double key = mKeyAxis->pixelToCoord(pos.x());
     double value = mValueAxis->pixelToCoord(pos.y());
 
-    bool foundKey = false, foundValue = false;
-    auto kr = mDataSource->keyRange(foundKey);
-    auto vr = mDataSource->valueRange(foundValue);
-
-    if (foundKey && foundValue && kr.contains(key) && vr.contains(value))
+    // Use the true scattered min/max, not the sorted first/last shortcut.
+    QCPRange kr, vr;
+    if (mDataSource->finiteKeyValueBounds(kr, vr) && kr.contains(key) && vr.contains(value))
         return 0;
     return -1;
 }

--- a/src/plottables/plottable-histogram2d.h
+++ b/src/plottables/plottable-histogram2d.h
@@ -56,6 +56,14 @@ public:
     void setNormalization(Normalization norm);
     Normalization normalization() const { return mNormalization; }
 
+    // Bin spacing per axis. Logarithmic spaces bin edges evenly in log10 and
+    // drops non-positive samples; it is meant to accompany a log-scaled axis
+    // (the renderer's uniform-pixel stretch reproduces log positions there).
+    void setKeyBinScale(QCPAxis::ScaleType type);
+    void setValueBinScale(QCPAxis::ScaleType type);
+    QCPAxis::ScaleType keyBinScale() const { return mKeyBinScale; }
+    QCPAxis::ScaleType valueBinScale() const { return mValueBinScale; }
+
     // Forwarded to QCPColormapRenderer
     QCPColorGradient gradient() const { return mRenderer.gradient(); }
     QCPRange dataRange() const { return mRenderer.dataRange(); }
@@ -94,6 +102,8 @@ private:
     int mKeyBins = 100;
     int mValueBins = 100;
     Normalization mNormalization = nNone;
+    QCPAxis::ScaleType mKeyBinScale = QCPAxis::stLinear;
+    QCPAxis::ScaleType mValueBinScale = QCPAxis::stLinear;
     QCPHistogramPipeline mPipeline;
     QCPColormapRenderer mRenderer;
 

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1300,6 +1300,22 @@ void TestPipeline::bin2dLogAllNonPositiveNoGrid()
 
 // --- QCPHistogram2D tests ---
 
+// Axis auto-scaling asks the plottable for its key range. Histogram keys are
+// scattered, not sorted, so it must report the true min/max, not first/last.
+void TestPipeline::histogram2dKeyRangeUnsorted()
+{
+    auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);
+    std::vector<double> keys = {5.0, 1.0, 9.0, 2.0}; // front=5, back=2; min=1, max=9
+    std::vector<double> vals = {0.0, 0.0, 0.0, 0.0};
+    hist->setData(std::move(keys), std::move(vals));
+
+    bool found = false;
+    QCPRange kr = hist->getKeyRange(found);
+    QVERIFY(found);
+    QCOMPARE(kr.lower, 1.0);
+    QCOMPARE(kr.upper, 9.0);
+}
+
 void TestPipeline::histogram2dPipelineBins()
 {
     auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1241,6 +1241,63 @@ void TestPipeline::bin2dAllNaNNoGrid()
     QVERIFY(!result);
 }
 
+// Log key binning: bin edges are evenly spaced in log space, so a decade of
+// keys lands one-per-bin instead of all piling into the first linear bin.
+void TestPipeline::bin2dLogKeyBinning()
+{
+    std::vector<double> keys = {1.0, 10.0, 100.0, 1000.0};
+    std::vector<double> vals = {5.0, 5.0, 5.0, 5.0};
+    auto src = std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::move(keys), std::move(vals));
+    // keyLog = true, valueLog = false
+    auto* result = qcp::algo::bin2d(*src, 3, 1, true, false);
+    QVERIFY(result);
+
+    // Grid keeps the linear coordinate extent [1, 1000]; the renderer's
+    // uniform-pixel stretch turns these log-spaced cells into log positions.
+    QCOMPARE(result->keyRange().lower, 1.0);
+    QCOMPARE(result->keyRange().upper, 1000.0);
+
+    // log10 range [0, 3], width/3 per bin: 1->bin0, 10->bin1, 100->bin2,
+    // 1000 (log 3) clamps to bin2.
+    QCOMPARE(result->cell(0, 0), 1.0);
+    QCOMPARE(result->cell(1, 0), 1.0);
+    QCOMPARE(result->cell(2, 0), 2.0);
+    delete result;
+}
+
+// On a log axis, non-positive keys can't be placed and are dropped like NaN;
+// the range derives from the positive keys only.
+void TestPipeline::bin2dLogDropsNonPositive()
+{
+    std::vector<double> keys = {-5.0, 1.0, 10.0, 100.0};
+    std::vector<double> vals = {5.0, 5.0, 5.0, 5.0};
+    auto src = std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::move(keys), std::move(vals));
+    auto* result = qcp::algo::bin2d(*src, 2, 1, true, false);
+    QVERIFY(result);
+
+    // -5 dropped: range is the positive extent [1, 100].
+    QCOMPARE(result->keyRange().lower, 1.0);
+    QCOMPARE(result->keyRange().upper, 100.0);
+
+    // log10 range [0, 2], width/2 per bin: 1->bin0, 10->bin1, 100->clamp bin1.
+    QCOMPARE(result->cell(0, 0), 1.0);
+    QCOMPARE(result->cell(1, 0), 2.0);
+    delete result;
+}
+
+// All keys non-positive on a log axis: nothing to bin, so no grid.
+void TestPipeline::bin2dLogAllNonPositiveNoGrid()
+{
+    std::vector<double> keys = {-1.0, -2.0, 0.0};
+    std::vector<double> vals = {1.0, 2.0, 3.0};
+    auto src = std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::move(keys), std::move(vals));
+    auto* result = qcp::algo::bin2d(*src, 4, 4, true, false);
+    QVERIFY(!result);
+}
+
 // --- QCPHistogram2D tests ---
 
 void TestPipeline::histogram2dPipelineBins()
@@ -1261,6 +1318,35 @@ void TestPipeline::histogram2dPipelineBins()
     QVERIFY(result);
     QCOMPARE(result->keySize(), 10);
     QCOMPARE(result->valueSize(), 20);
+}
+
+void TestPipeline::histogram2dBinScaleDefaultsLinear()
+{
+    auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);
+    QCOMPARE(hist->keyBinScale(), QCPAxis::stLinear);
+    QCOMPARE(hist->valueBinScale(), QCPAxis::stLinear);
+}
+
+void TestPipeline::histogram2dLogKeyBinScaleRebins()
+{
+    auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);
+    hist->setBins(3, 1);
+    hist->setKeyBinScale(QCPAxis::stLogarithmic);
+    QCOMPARE(hist->keyBinScale(), QCPAxis::stLogarithmic);
+
+    std::vector<double> keys = {1.0, 10.0, 100.0, 1000.0};
+    std::vector<double> vals = {5.0, 5.0, 5.0, 5.0};
+    hist->setData(std::move(keys), std::move(vals));
+
+    QSignalSpy spy(&hist->pipeline(), &QCPHistogramPipeline::finished);
+    QVERIFY(spy.wait(2000));
+
+    auto* data = hist->pipeline().result();
+    QVERIFY(data);
+    // Log key bins spread the decade one-per-bin (vs all in bin 0 if linear).
+    QCOMPARE(data->cell(0, 0), 1.0);
+    QCOMPARE(data->cell(1, 0), 1.0);
+    QCOMPARE(data->cell(2, 0), 2.0);
 }
 
 void TestPipeline::histogram2dNormalizationColumn()

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1183,6 +1183,64 @@ void TestPipeline::bin2dSingleBin()
     delete result;
 }
 
+// Histogram input is scattered, NOT sorted by key. The bin range must be the
+// true min/max of the keys, not the first/last sample. Here the min (1.0) and
+// max (9.0) are interior; the endpoints are both 2.0.
+void TestPipeline::bin2dUnsortedKeyRange()
+{
+    std::vector<double> keys = {2.0, 1.0, 9.0, 2.0};
+    std::vector<double> vals = {0.0, 0.0, 0.0, 0.0};
+    auto src = std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::move(keys), std::move(vals));
+    auto* result = qcp::algo::bin2d(*src, 4, 1);
+    QVERIFY(result);
+
+    // The grid must span the real key extent [1, 9], not the endpoints [2, 2].
+    QCOMPARE(result->keyRange().lower, 1.0);
+    QCOMPARE(result->keyRange().upper, 9.0);
+
+    // With binWidth = 8/4 = 2: keys 2,1,2 fall in column 0, key 9 clamps to 3.
+    QCOMPARE(result->cell(0, 0), 3.0);
+    QCOMPARE(result->cell(1, 0), 0.0);
+    QCOMPARE(result->cell(2, 0), 0.0);
+    QCOMPARE(result->cell(3, 0), 1.0);
+    delete result;
+}
+
+// A non-finite sample at the first/last key position must not poison the range.
+// The finite points must still bin against the finite min/max.
+void TestPipeline::bin2dNaNAtKeyEndpoint()
+{
+    const double nan = std::nan("");
+    std::vector<double> keys = {nan, 2.0, 6.0, nan};
+    std::vector<double> vals = {1.0, 0.0, 0.0, 1.0};
+    auto src = std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::move(keys), std::move(vals));
+    auto* result = qcp::algo::bin2d(*src, 2, 1);
+    QVERIFY(result);
+
+    // Range derives only from finite keys: [2, 6].
+    QCOMPARE(result->keyRange().lower, 2.0);
+    QCOMPARE(result->keyRange().upper, 6.0);
+
+    // binWidth = 4/2 = 2: key 2 -> col 0, key 6 -> clamps to col 1. NaN dropped.
+    QCOMPARE(result->cell(0, 0), 1.0);
+    QCOMPARE(result->cell(1, 0), 1.0);
+    delete result;
+}
+
+// All keys non-finite: no finite sample to bin, so no grid.
+void TestPipeline::bin2dAllNaNNoGrid()
+{
+    const double nan = std::nan("");
+    std::vector<double> keys = {nan, nan, nan};
+    std::vector<double> vals = {1.0, 2.0, 3.0};
+    auto src = std::make_shared<QCPSoADataSource<std::vector<double>, std::vector<double>>>(
+        std::move(keys), std::move(vals));
+    auto* result = qcp::algo::bin2d(*src, 4, 4);
+    QVERIFY(!result);
+}
+
 // --- QCPHistogram2D tests ---
 
 void TestPipeline::histogram2dPipelineBins()

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -86,12 +86,17 @@ private slots:
     void bin2dUnsortedKeyRange();
     void bin2dNaNAtKeyEndpoint();
     void bin2dAllNaNNoGrid();
+    void bin2dLogKeyBinning();
+    void bin2dLogDropsNonPositive();
+    void bin2dLogAllNonPositiveNoGrid();
 
     // QCPHistogram2D
     void histogram2dPipelineBins();
     void histogram2dNormalizationColumn();
     void histogram2dNormalizationToggleNoRebind();
     void histogram2dRenderSmokeTest();
+    void histogram2dLogKeyBinScaleRebins();
+    void histogram2dBinScaleDefaultsLinear();
 
     // Layer-level GPU translation
     void stallPixelOffsetGraph2Busy();

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -83,6 +83,9 @@ private slots:
     void bin2dNaNSkipped();
     void bin2dEmptyInput();
     void bin2dSingleBin();
+    void bin2dUnsortedKeyRange();
+    void bin2dNaNAtKeyEndpoint();
+    void bin2dAllNaNNoGrid();
 
     // QCPHistogram2D
     void histogram2dPipelineBins();

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -91,6 +91,7 @@ private slots:
     void bin2dLogAllNonPositiveNoGrid();
 
     // QCPHistogram2D
+    void histogram2dKeyRangeUnsorted();
     void histogram2dPipelineBins();
     void histogram2dNormalizationColumn();
     void histogram2dNormalizationToggleNoRebind();


### PR DESCRIPTION
## Summary

Fixes the Histogram2D binning range (it assumed sorted keys), makes it NaN-safe, and adds per-axis **logarithmic bin spacing**. No renderer changes were needed — the colormap renderer stretches cells uniformly in pixel space, which on a log axis is uniform in log.

## Commits
- **compute bin range from finite, unsorted (key,value) bounds** — `bin2d` used `keyRange()` (the SoA source's sorted first/last shortcut), wrong for scattered histogram X data, and not NaN-safe. New NaN-safe, pairwise `QCPAbstractDataSource::finiteKeyValueBounds()` (base default + typed SoA override) computes the true min/max; `bin2d` uses it.
- **per-axis logarithmic bin spacing** — `bin2d(..., keyLog, valueLog)` spaces bin edges in log10 and drops non-positive samples; `QCPHistogram2D::setKeyBinScale()/setValueBinScale()` (default linear, re-bins on change).
- **unsorted key range in getKeyRange/selectTest; assert log invariant** — the same sorted-range bug in the axis-autoscale / hit-test path; both now use `finiteKeyValueBounds()`. Debug assert documents the "log ⇒ positive range" invariant.

## Tests
`tests/auto/test-pipeline`: unsorted-key range, NaN endpoints, all-NaN, log binning (+positive filter + all-non-positive), bin-scale property re-bin, and `getKeyRange` on unsorted data. **91 pass / 0 fail** (4 RHI skips, headless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)