### PR TITLE
feat(histogram2d): bin scale follows the axis scale type

### DIFF
--- a/src/plottables/plottable-histogram2d.cpp
+++ b/src/plottables/plottable-histogram2d.cpp
@@ -24,6 +24,19 @@ QCPHistogram2D::QCPHistogram2D(QCPAxis* keyAxis, QCPAxis* valueAxis)
             });
     connect(&mPipeline, &QCPHistogramPipeline::busyChanged,
             this, [this](bool) { updateEffectiveBusy(); });
+
+    // Binning follows the axis scale: re-bin whenever an axis toggles log/linear
+    // so the picture re-distributes (the renderer can't reposition cells itself).
+    if (keyAxis)
+        connect(keyAxis, &QCPAxis::scaleTypeChanged, this, &QCPHistogram2D::refreshBinning);
+    if (valueAxis)
+        connect(valueAxis, &QCPAxis::scaleTypeChanged, this, &QCPHistogram2D::refreshBinning);
+}
+
+void QCPHistogram2D::refreshBinning()
+{
+    installTransform();
+    mPipeline.onDataChanged();
 }
 
 QCPHistogram2D::~QCPHistogram2D()
@@ -35,8 +48,8 @@ void QCPHistogram2D::installTransform()
 {
     int capturedKeyBins = mKeyBins;
     int capturedValueBins = mValueBins;
-    const bool keyLog = mKeyBinScale == QCPAxis::stLogarithmic;
-    const bool valueLog = mValueBinScale == QCPAxis::stLogarithmic;
+    const bool keyLog = mKeyAxis && mKeyAxis->scaleType() == QCPAxis::stLogarithmic;
+    const bool valueLog = mValueAxis && mValueAxis->scaleType() == QCPAxis::stLogarithmic;
 
     mPipeline.setTransform(TransformKind::ViewportIndependent,
         [capturedKeyBins, capturedValueBins, keyLog, valueLog](
@@ -79,20 +92,24 @@ void QCPHistogram2D::setBins(int keyBins, int valueBins)
 
 void QCPHistogram2D::setKeyBinScale(QCPAxis::ScaleType type)
 {
-    if (mKeyBinScale == type)
-        return;
-    mKeyBinScale = type;
-    installTransform();
-    mPipeline.onDataChanged();
+    if (mKeyAxis)
+        mKeyAxis->setScaleType(type); // scaleTypeChanged -> re-bin
 }
 
 void QCPHistogram2D::setValueBinScale(QCPAxis::ScaleType type)
 {
-    if (mValueBinScale == type)
-        return;
-    mValueBinScale = type;
-    installTransform();
-    mPipeline.onDataChanged();
+    if (mValueAxis)
+        mValueAxis->setScaleType(type);
+}
+
+QCPAxis::ScaleType QCPHistogram2D::keyBinScale() const
+{
+    return mKeyAxis ? mKeyAxis->scaleType() : QCPAxis::stLinear;
+}
+
+QCPAxis::ScaleType QCPHistogram2D::valueBinScale() const
+{
+    return mValueAxis ? mValueAxis->scaleType() : QCPAxis::stLinear;
 }
 
 void QCPHistogram2D::setNormalization(Normalization norm)

--- a/src/plottables/plottable-histogram2d.h
+++ b/src/plottables/plottable-histogram2d.h
@@ -56,13 +56,20 @@ public:
     void setNormalization(Normalization norm);
     Normalization normalization() const { return mNormalization; }
 
-    // Bin spacing per axis. Logarithmic spaces bin edges evenly in log10 and
-    // drops non-positive samples; it is meant to accompany a log-scaled axis
-    // (the renderer's uniform-pixel stretch reproduces log positions there).
+    // Bin spacing follows the key/value axis scale: a logarithmic axis bins in
+    // log10 (dropping non-positive samples), so the histogram re-distributes when
+    // the axis scale is toggled (the renderer only stretches cells uniformly in
+    // pixels, so the bin layout must match the axis to be correct). These setters
+    // are convenience aliases that set the corresponding axis scale type.
     void setKeyBinScale(QCPAxis::ScaleType type);
     void setValueBinScale(QCPAxis::ScaleType type);
-    QCPAxis::ScaleType keyBinScale() const { return mKeyBinScale; }
-    QCPAxis::ScaleType valueBinScale() const { return mValueBinScale; }
+    QCPAxis::ScaleType keyBinScale() const;
+    QCPAxis::ScaleType valueBinScale() const;
+
+    // Re-read the key/value axis scale type and re-bin. Wired to the axes'
+    // scaleTypeChanged, but also callable directly for callers that change the
+    // scale with that signal blocked (e.g. SciQLop's axis wrapper).
+    Q_SLOT void refreshBinning();
 
     // Forwarded to QCPColormapRenderer
     QCPColorGradient gradient() const { return mRenderer.gradient(); }
@@ -102,8 +109,6 @@ private:
     int mKeyBins = 100;
     int mValueBins = 100;
     Normalization mNormalization = nNone;
-    QCPAxis::ScaleType mKeyBinScale = QCPAxis::stLinear;
-    QCPAxis::ScaleType mValueBinScale = QCPAxis::stLinear;
     QCPHistogramPipeline mPipeline;
     QCPColormapRenderer mRenderer;
 

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1365,6 +1365,37 @@ void TestPipeline::histogram2dLogKeyBinScaleRebins()
     QCOMPARE(data->cell(2, 0), 2.0);
 }
 
+// The core of "changing the scale changes the look": toggling the key axis
+// between linear and log after data is set must re-bin, since the renderer can
+// only stretch cells uniformly and cannot redistribute them itself.
+void TestPipeline::histogram2dAxisScaleTogglesRebinning()
+{
+    auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);
+    hist->setBins(3, 1);
+    std::vector<double> keys = {1.0, 10.0, 100.0, 1000.0};
+    std::vector<double> vals = {5.0, 5.0, 5.0, 5.0};
+    hist->setData(std::move(keys), std::move(vals));
+
+    QSignalSpy spy(&hist->pipeline(), &QCPHistogramPipeline::finished);
+    QVERIFY(spy.wait(2000));
+    auto* lin = hist->pipeline().result();
+    QVERIFY(lin);
+    // Linear range [1, 1000], binWidth 333: 1/10/100 -> bin 0, 1000 -> bin 2.
+    QCOMPARE(lin->cell(0, 0), 3.0);
+    QCOMPARE(lin->cell(2, 0), 1.0);
+
+    // Toggle the key axis to log -> the histogram must re-bin in log space.
+    QSignalSpy spy2(&hist->pipeline(), &QCPHistogramPipeline::finished);
+    mPlot->xAxis->setScaleType(QCPAxis::stLogarithmic);
+    QVERIFY(spy2.wait(2000));
+    auto* log = hist->pipeline().result();
+    QVERIFY(log);
+    // log10 range [0, 3]: 1->0, 10->1, 100->2, 1000 clamps to 2.
+    QCOMPARE(log->cell(0, 0), 1.0);
+    QCOMPARE(log->cell(1, 0), 1.0);
+    QCOMPARE(log->cell(2, 0), 2.0);
+}
+
 void TestPipeline::histogram2dNormalizationColumn()
 {
     auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -98,6 +98,7 @@ private slots:
     void histogram2dRenderSmokeTest();
     void histogram2dLogKeyBinScaleRebins();
     void histogram2dBinScaleDefaultsLinear();
+    void histogram2dAxisScaleTogglesRebinning();
 
     // Layer-level GPU translation
     void stallPixelOffsetGraph2Busy();


### PR DESCRIPTION
## Summary

Couples Histogram2D's bin spacing to its **axis scale** so that toggling an axis between linear and log actually changes the picture.

## Why

`QCPColormapRenderer` only stretches the binned grid **uniformly in pixels** between the data's min/max — which always map to the axis-rect edges. So flipping an axis linear↔log produces a *pixel-identical* image (only the ticks change); the renderer never repositions interior cells. A linear-binned histogram on a log axis is therefore simply wrong, and toggling the scale did nothing on screen.

The colormap/spectrogram already avoids this by re-binning to match the axis (its resampler reads `valueLogScale`). This makes Histogram2D behave the same.

## What

- `installTransform()` now reads `mKeyAxis`/`mValueAxis` scale type; the constructor connects their `QCPAxis::scaleTypeChanged` to a new public slot `refreshBinning()` (re-install transform + re-bin), so the grid redistributes live when the scale is toggled.
- `setKeyBinScale`/`setValueBinScale` become thin aliases that set the corresponding axis scale type; `keyBinScale`/`valueBinScale` read it back. No separate bin-scale state remains, so the binning can never disagree with the axis.
- `refreshBinning()` is also callable directly, for callers that change the scale with `scaleTypeChanged` blocked (e.g. SciQLop's axis wrapper, which uses a `QSignalBlocker`).

## Tests

`tests/auto/test-pipeline`: toggling the key axis between linear and log after data is set re-bins (linear pile-up → one-per-decade in log). **92 pass / 0 fail** (4 RHI skips, headless).

Builds on #28 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)