### PR TITLE
fix: honor plottable visibility for colormap RHI compositing + mouseTransparent overlays

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2699,6 +2699,8 @@ void QCustomPlot::uploadLayerTextures(QRhiResourceUpdateBatch* updates, const QS
 
     for (auto* crl : mColormapRhiLayers)
     {
+        if (!crl->ownerVisible())
+            continue;
         crl->ensurePipeline(renderTarget()->renderPassDescriptor(), sampleCount(),
                             mCompositeUbo);
         crl->uploadResources(updates, outputSize, mBufferDevicePixelRatio,
@@ -2834,7 +2836,7 @@ void QCustomPlot::executeRenderPass(QRhiCommandBuffer* cb, QRhiResourceUpdateBat
         bool hasColormapsOnLayer = false;
         for (auto* crl : mColormapRhiLayers)
         {
-            if (crl->layer() == layer && crl->hasContent())
+            if (crl->layer() == layer && crl->hasContent() && crl->ownerVisible())
             {
                 if (!hasColormapsOnLayer)
                 {
@@ -3920,6 +3922,8 @@ QList<QCPLayerable*> QCustomPlot::layerableListAt(const QPointF& pos, bool onlyS
         for (int i = layerables.size() - 1; i >= 0; --i)
         {
             if (!layerables.at(i)->realVisibility())
+                continue;
+            if (layerables.at(i)->mouseTransparent())
                 continue;
             QVariant details;
             double dist = layerables.at(i)->selectTest(pos, onlySelectable,

--- a/src/layer.h
+++ b/src/layer.h
@@ -130,6 +130,7 @@ class QCP_LIB_DECL QCPLayerable : public QObject
     Q_PROPERTY(QCPLayerable* parentLayerable READ parentLayerable)
     Q_PROPERTY(QCPLayer* layer READ layer WRITE setLayer NOTIFY layerChanged)
     Q_PROPERTY(bool antialiased READ antialiased WRITE setAntialiased)
+    Q_PROPERTY(bool mouseTransparent READ mouseTransparent WRITE setMouseTransparent)
     /// \endcond
 
 public:
@@ -148,11 +149,18 @@ public:
 
     [[nodiscard]] bool antialiased() const { return mAntialiased; }
 
+    // When true, this layerable is skipped by hit-testing (layerableListAt), so
+    // it never captures mouse clicks/hover nor shadows interactive elements
+    // beneath it. Use for purely decorative overlays (e.g. a crosshair) that
+    // would otherwise steal clicks from the legend/plottables below.
+    [[nodiscard]] bool mouseTransparent() const { return mMouseTransparent; }
+
     // setters:
     void setVisible(bool on);
     Q_SLOT bool setLayer(QCPLayer* layer);
     bool setLayer(const QString& layerName);
     void setAntialiased(bool enabled);
+    void setMouseTransparent(bool transparent) { mMouseTransparent = transparent; }
 
     // introduced virtual methods:
     virtual double selectTest(const QPointF& pos, bool onlySelectable,
@@ -171,6 +179,7 @@ protected:
     QPointer<QCPLayerable> mParentLayerable;
     QCPLayer* mLayer;
     bool mAntialiased;
+    bool mMouseTransparent = false;
 
     // introduced virtual methods:
     virtual void parentPlotInitialized(QCustomPlot* parentPlot);

--- a/src/painting/colormap-renderer.cpp
+++ b/src/painting/colormap-renderer.cpp
@@ -177,6 +177,7 @@ QCPColormapRhiLayer* QCPColormapRenderer::ensureRhiLayer()
     if (!mRhiLayer && plot && plot->rhi())
     {
         mRhiLayer = new QCPColormapRhiLayer(plot->rhi());
+        mRhiLayer->setOwner(mOwner);
         plot->registerColormapRhiLayer(mRhiLayer);
     }
     return mRhiLayer;

--- a/src/painting/colormap-rhi-layer.cpp
+++ b/src/painting/colormap-rhi-layer.cpp
@@ -2,7 +2,13 @@
 #include "embedded_shaders.h"
 #include "rhi-utils.h"
 #include "Profiling.hpp"
+#include "../layer.h"
 #include <cstring>
+
+bool QCPColormapRhiLayer::ownerVisible() const
+{
+    return !mOwner || mOwner->realVisibility();
+}
 
 // ── Contour line UBO (std140, 32 bytes) ────────────────────────────────────
 // Must match contour_line.vert/frag ContourLineParams exactly.

--- a/src/painting/colormap-rhi-layer.h
+++ b/src/painting/colormap-rhi-layer.h
@@ -8,6 +8,7 @@
 #include <rhi/qrhi.h>
 
 class QCPLayer;
+class QCPLayerable;
 
 class QCPColormapRhiLayer
 {
@@ -20,6 +21,14 @@ public:
     void setScissorRect(const QRect& scissor);
     void setLayer(QCPLayer* layer) { mLayer = layer; }
     QCPLayer* layer() const { return mLayer; }
+
+    // The colormap plottable this RHI layer renders for. The compositor skips
+    // layers whose owner is not really visible — without this a hidden colormap
+    // keeps compositing its last frame (its draw() stops being called, so the
+    // quad is never updated and it freezes in place during pans).
+    void setOwner(QCPLayerable* owner) { mOwner = owner; }
+    QCPLayerable* owner() const { return mOwner; }
+    bool ownerVisible() const;
 
     void setContourLines(QVector<float> uvVertices, const QColor& color);
     void clearContourLines();
@@ -38,6 +47,7 @@ public:
 private:
     QRhi* mRhi;
     QCPLayer* mLayer = nullptr;
+    QCPLayerable* mOwner = nullptr;
 
     // CPU staging — colormap
     QImage mStagingImage;


### PR DESCRIPTION
## Summary

Two visibility/interaction correctness fixes for the RHI pipeline, both surfaced while wiring up "hide/show any curve, component, or colormap" in SciQLopPlots:

- **Hidden colormaps no longer freeze on screen.** `QCPColorMap2` composites through a registered RHI layer. When the plottable is set invisible its `draw()` simply stops being called, so the layer's quad is never updated — it kept compositing its last frame and stayed frozen in place during pans. The RHI layer now carries its owning plottable and an `ownerVisible()` check; the compositor skips both resource upload and draw for colormaps whose owner is not really visible.

- **Decorative overlays no longer steal clicks.** Added `QCPLayerable::setMouseTransparent(bool)`. `layerableListAt()` skips mouse-transparent layerables, so purely decorative overlays (e.g. a crosshair following the cursor on the topmost layer) no longer shadow interactive elements beneath them. Previously such an overlay became `candidates.first()` in `mouseDoubleClickEvent`, so QCP emitted `itemDoubleClick` instead of `legendDoubleClick` — breaking legend double-click handling while the crosshair was enabled. `setSelectable(false)` did not help because hit-testing runs with `onlySelectable = false`.

## Details

- `QCPLayerable`: new `mMouseTransparent` flag (default false → no behavior change), `setMouseTransparent`/`mouseTransparent`, and `Q_PROPERTY`.
- `QCustomPlot::layerableListAt`: skip layerables with `mouseTransparent() == true`.
- `QCPColormapRhiLayer`: new `owner`/`setOwner`/`ownerVisible()`; the renderer sets the owner when it creates the layer.
- `QCustomPlot` compositor: gate the colormap upload loop and draw loop on `ownerVisible()`.

## Test plan

- [ ] Build (`meson compile`) — unity + non-unity.
- [ ] Existing `auto-tests` pass (colormap, legend, layout, core).
- [ ] Downstream SciQLopPlots: full integration suite (704 passing) — hide a colormap (checkbox / legend double-click) and confirm it disappears and pans correctly; double-click legend with crosshair enabled hides/shows the curve.

Default behavior is unchanged for existing users: `mMouseTransparent` defaults to false, and the colormap visibility gate only skips layers whose owner is genuinely not visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)