### PR TITLE
fix(datasource): degrade to empty on shape lies instead of Q_ASSERT-only validation

### DIFF
--- a/src/datasource/row-major-multi-datasource.h
+++ b/src/datasource/row-major-multi-datasource.h
@@ -79,10 +79,23 @@ public:
         : mKeys(keys), mValues(values), mRows(rows), mColumns(columns), mStride(stride),
           mDataGuard(std::move(dataGuard))
     {
-        Q_ASSERT(rows >= 0 && columns >= 0 && stride > 0);
-        Q_ASSERT(static_cast<int>(keys.size()) == rows);
-        Q_ASSERT(stride >= columns);
-        Q_ASSERT(values != nullptr || rows == 0);
+        // Shape lies from callers must degrade to an empty source, not become
+        // OOB reads (release) or aborts (debug) — this is a public entry point.
+        const bool valid = rows > 0 && columns >= 0 && stride > 0 && stride >= columns
+            && static_cast<int>(keys.size()) == rows && values != nullptr;
+        if (!valid)
+        {
+            if (rows != 0)
+                qWarning("QCPRowMajorMultiDataSource: invalid shape (rows=%d, columns=%d, "
+                         "stride=%d, keys=%zu, values=%p) — dropping data",
+                         rows, columns, stride, keys.size(),
+                         static_cast<const void*>(values));
+            mKeys = {};
+            mValues = nullptr;
+            mRows = 0;
+            mColumns = 0;
+            mStride = 1;
+        }
     }
 
     int columnCount() const override { return mColumns; }

--- a/src/datasource/row-major-multi-datasource.h
+++ b/src/datasource/row-major-multi-datasource.h
@@ -85,7 +85,9 @@ public:
             && static_cast<int>(keys.size()) == rows && values != nullptr;
         if (!valid)
         {
-            if (rows != 0)
+            // Genuinely empty input (rows == 0, no keys) stays silent; any
+            // other combination is a shape lie worth a diagnostic.
+            if (rows != 0 || !keys.empty())
                 qWarning("QCPRowMajorMultiDataSource: invalid shape (rows=%d, columns=%d, "
                          "stride=%d, keys=%zu, values=%p) — dropping data",
                          rows, columns, stride, keys.size(),

--- a/src/datasource/soa-datasource-2d.h
+++ b/src/datasource/soa-datasource-2d.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "abstract-datasource-2d.h"
 #include "algorithms-2d.h"
+#include <QtGlobal>
 #include <memory>
 #include <ranges>
 #include <span>
@@ -17,13 +18,30 @@ public:
         : mX(std::move(x)), mY(std::move(y)), mZ(std::move(z)),
           mDataGuard(std::move(dataGuard))
     {
-        auto nx = std::ranges::size(mX);
-        auto ny = std::ranges::size(mY);
-        auto nz = std::ranges::size(mZ);
-        Q_ASSERT(nx > 0 && nz > 0 && nz % nx == 0);
-        mYSize = static_cast<int>(nz / nx);
-        mYIs2D = (ny == nz);
-        Q_ASSERT(ny == nz || ny == static_cast<decltype(ny)>(mYSize));
+        const auto nx = std::ranges::size(mX);
+        const auto ny = std::ranges::size(mY);
+        const auto nz = std::ranges::size(mZ);
+        // Shape lies from callers must degrade to an empty source, not become
+        // OOB reads (release) or aborts (debug) — this is a public entry point.
+        const bool valid = nx > 0 && nz > 0 && nz % nx == 0
+            && (ny == nz || ny == nz / nx);
+        if (valid)
+        {
+            mYSize = static_cast<int>(nz / nx);
+            mYIs2D = (ny == nz);
+        }
+        else
+        {
+            if (nx != 0 || ny != 0 || nz != 0)
+                qWarning("QCPSoADataSource2D: inconsistent shapes (nx=%zu, ny=%zu, nz=%zu) — dropping data",
+                         static_cast<std::size_t>(nx), static_cast<std::size_t>(ny),
+                         static_cast<std::size_t>(nz));
+            mX = {};
+            mY = {};
+            mZ = {};
+            mYSize = 0;
+            mYIs2D = false;
+        }
     }
 
     const XC& x() const { return mX; }

--- a/src/datasource/soa-datasource.h
+++ b/src/datasource/soa-datasource.h
@@ -16,7 +16,16 @@ public:
         : mKeys(std::move(keys)), mValues(std::move(values)),
           mDataGuard(std::move(dataGuard))
     {
-        Q_ASSERT(std::ranges::size(mKeys) == std::ranges::size(mValues));
+        // Shape lies from callers must degrade to an empty source, not become
+        // OOB reads (release) or aborts (debug) — this is a public entry point.
+        if (std::ranges::size(mKeys) != std::ranges::size(mValues))
+        {
+            qWarning("QCPSoADataSource: keys/values length mismatch (%zu vs %zu) — dropping data",
+                     static_cast<std::size_t>(std::ranges::size(mKeys)),
+                     static_cast<std::size_t>(std::ranges::size(mValues)));
+            mKeys = {};
+            mValues = {};
+        }
     }
 
     const KeyContainer& keys() const { return mKeys; }

--- a/src/datasource/soa-multi-datasource.h
+++ b/src/datasource/soa-multi-datasource.h
@@ -16,8 +16,20 @@ public:
         : mKeys(std::move(keys)), mValues(std::move(valueColumns)),
           mDataGuard(std::move(dataGuard))
     {
+        // Shape lies from callers must degrade to an empty source, not become
+        // OOB reads (release) or aborts (debug) — this is a public entry point.
         for (const auto& col : mValues)
-            Q_ASSERT(std::ranges::size(col) == std::ranges::size(mKeys));
+        {
+            if (std::ranges::size(col) != std::ranges::size(mKeys))
+            {
+                qWarning("QCPSoAMultiDataSource: column length mismatch (%zu vs %zu keys) — dropping data",
+                         static_cast<std::size_t>(std::ranges::size(col)),
+                         static_cast<std::size_t>(std::ranges::size(mKeys)));
+                mKeys = {};
+                mValues.clear();
+                break;
+            }
+        }
     }
 
     int columnCount() const override { return static_cast<int>(mValues.size()); }

--- a/tests/auto/test-datasource/test-datasource.cpp
+++ b/tests/auto/test-datasource/test-datasource.cpp
@@ -191,6 +191,24 @@ void TestDataSource::soaIntValues()
     QCOMPARE(src.valueAt(2), 300.0);
 }
 
+void TestDataSource::soaMismatchedLengthsDegradeToEmpty()
+{
+    // Shape lies from callers must not become OOB reads (release) or aborts
+    // (debug): the source degrades to empty with a warning.
+    std::vector<double> keys = {1.0, 2.0, 3.0};
+    std::vector<double> values = {10.0, 20.0};
+    QCPSoADataSource<std::vector<double>, std::vector<double>> src(
+        std::move(keys), std::move(values));
+
+    QCOMPARE(src.size(), 0);
+    QVERIFY(src.empty());
+    bool found = true;
+    src.keyRange(found);
+    QVERIFY(!found);
+    src.valueRange(found);
+    QVERIFY(!found);
+}
+
 // QCPGraph2 integration tests
 void TestDataSource::graph2Creation()
 {

--- a/tests/auto/test-datasource/test-datasource.h
+++ b/tests/auto/test-datasource/test-datasource.h
@@ -24,6 +24,7 @@ private slots:
     void soaFindBeginEnd();
     void soaRangeQueries();
     void soaIntValues();
+    void soaMismatchedLengthsDegradeToEmpty();
 
     // QCPGraph2 integration tests
     void graph2Creation();

--- a/tests/auto/test-datasource2d/test-datasource2d.cpp
+++ b/tests/auto/test-datasource2d/test-datasource2d.cpp
@@ -173,6 +173,41 @@ void TestDataSource2D::soa2dRangeQueries()
     QCOMPARE(src.findXBegin(2.0), 0);
     QCOMPARE(src.findXEnd(4.0), 3);
 }
+
+void TestDataSource2D::soa2dInvalidShapesDegradeToEmpty()
+{
+    // Shape lies must not become OOB reads (release) or aborts (debug):
+    // the source degrades to empty with a warning.
+    {
+        // nz not a multiple of nx
+        std::vector<double> x = {1.0, 2.0, 3.0};
+        std::vector<double> y = {10.0, 20.0};
+        std::vector<double> z = {1.0, 2.0, 3.0, 4.0, 5.0};
+        QCPSoADataSource2D src(std::move(x), std::move(y), std::move(z));
+        QCOMPARE(src.xSize(), 0);
+        QCOMPARE(src.ySize(), 0);
+        bool found = true;
+        src.xRange(found);
+        QVERIFY(!found);
+    }
+    {
+        // y matches neither nz (2D) nor nz/nx (1D)
+        std::vector<double> x = {1.0, 2.0, 3.0};
+        std::vector<double> y = {10.0, 20.0, 30.0};
+        std::vector<double> z = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        QCPSoADataSource2D src(std::move(x), std::move(y), std::move(z));
+        QCOMPARE(src.xSize(), 0);
+        QCOMPARE(src.ySize(), 0);
+    }
+    {
+        // genuinely empty input stays empty without warning or crash
+        QCPSoADataSource2D src(std::vector<double>{}, std::vector<double>{},
+                               std::vector<double>{});
+        QCOMPARE(src.xSize(), 0);
+        QCOMPARE(src.ySize(), 0);
+    }
+}
+
 void TestDataSource2D::resampleUniformGrid()
 {
     std::vector<double> x = {0.0, 1.0, 2.0, 3.0, 4.0};

--- a/tests/auto/test-datasource2d/test-datasource2d.h
+++ b/tests/auto/test-datasource2d/test-datasource2d.h
@@ -23,6 +23,7 @@ private slots:
     void soa2dSpanView();
     void soa2dMixedTypes();
     void soa2dRangeQueries();
+    void soa2dInvalidShapesDegradeToEmpty();
 
     // Resample algorithm tests
     void resampleUniformGrid();

--- a/tests/auto/test-multi-datasource/test-multi-datasource.cpp
+++ b/tests/auto/test-multi-datasource/test-multi-datasource.cpp
@@ -444,6 +444,50 @@ void TestMultiDataSource::rowMajorGetLines()
     QVERIFY(optLines.size() <= 5);
 }
 
+void TestMultiDataSource::soaMismatchedColumnDegradesToEmpty()
+{
+    // A value column shorter than the keys must not become an OOB read
+    // (release) or abort (debug): the source degrades to empty with a warning.
+    std::vector<double> keys = {1.0, 2.0, 3.0};
+    std::vector<std::vector<double>> columns;
+    columns.push_back({10.0, 20.0, 30.0});
+    columns.push_back({40.0, 50.0}); // short column, wrong on purpose
+    QCPSoAMultiDataSource<std::vector<double>, std::vector<double>> src(
+        std::move(keys), std::move(columns));
+
+    QCOMPARE(src.size(), 0);
+    QCOMPARE(src.columnCount(), 0);
+    bool found = true;
+    src.keyRange(found);
+    QVERIFY(!found);
+}
+
+void TestMultiDataSource::rowMajorInvalidShapeDegradesToEmpty()
+{
+    std::vector<double> keys = {1.0, 2.0, 3.0};
+    std::vector<double> values = {10, 20, 30, 40, 50, 60};
+
+    {
+        // keys shorter than rows
+        QCPRowMajorMultiDataSource<double, double> src(
+            std::span<const double>(keys.data(), 2), values.data(), 3, 2, 2);
+        QCOMPARE(src.size(), 0);
+        QCOMPARE(src.columnCount(), 0);
+    }
+    {
+        // stride narrower than the column count
+        QCPRowMajorMultiDataSource<double, double> src(
+            std::span<const double>(keys), values.data(), 3, 2, 1);
+        QCOMPARE(src.size(), 0);
+    }
+    {
+        // null values with rows > 0
+        QCPRowMajorMultiDataSource<double, double> src(
+            std::span<const double>(keys), nullptr, 3, 2, 2);
+        QCOMPARE(src.size(), 0);
+    }
+}
+
 // Helper: build an L1 cache with uniform keys and per-column values
 static qcp::algo::MultiGraphResamplerCache makeL1Cache(
     const std::vector<double>& keys,

--- a/tests/auto/test-multi-datasource/test-multi-datasource.cpp
+++ b/tests/auto/test-multi-datasource/test-multi-datasource.cpp
@@ -486,6 +486,15 @@ void TestMultiDataSource::rowMajorInvalidShapeDegradesToEmpty()
             std::span<const double>(keys), nullptr, 3, 2, 2);
         QCOMPARE(src.size(), 0);
     }
+    {
+        // rows == 0 with non-empty keys is a shape lie, not a genuinely
+        // empty source: it must warn like the other mismatch paths
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("QCPRowMajorMultiDataSource: invalid shape"));
+        QCPRowMajorMultiDataSource<double, double> src(
+            std::span<const double>(keys), values.data(), 0, 2, 2);
+        QCOMPARE(src.size(), 0);
+    }
 }
 
 // Helper: build an L1 cache with uniform keys and per-column values

--- a/tests/auto/test-multi-datasource/test-multi-datasource.h
+++ b/tests/auto/test-multi-datasource/test-multi-datasource.h
@@ -38,6 +38,10 @@ private slots:
     void rowMajorWithPadding();
     void rowMajorGetLines();
 
+    // Shape validation (degrade to empty, never UB/abort)
+    void soaMismatchedColumnDegradesToEmpty();
+    void rowMajorInvalidShapeDegradesToEmpty();
+
     // resampleL2Multi correctness
     void l2MultiBasicMinMax();
     void l2MultiNanSkipped();


### PR DESCRIPTION
The SoA/multi/row-major/2D data source constructors validated caller shapes with `Q_ASSERT` alone: compiled out in release builds the lies became out-of-bounds reads (e.g. `mYSize` derived from a non-multiple nz), and in debug builds they aborted the host application. These are public entry points fed with arbitrary user data by downstream consumers (SciQLopPlots).

Constructors now check the same invariants unconditionally and degrade to an empty source with a `qWarning` when violated; genuinely empty input stays silently empty. `Q_ASSERT` remains in the hot index accessors.

**Tests** (all aborted via QFATAL ASSERT before the fix):
- `soaMismatchedLengthsDegradeToEmpty`
- `soaMismatchedColumnDegradesToEmpty`
- `rowMajorInvalidShapeDegradesToEmpty`
- `soa2dInvalidShapesDegradeToEmpty`

Part of the 2026-06-09 audit (H8 in SciQLopPlots `docs/backlog-2026-06-10.md`); companion to the SciQLopPlots set_data-hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)