### PR TITLE
fix(pipeline): make async jobs safe against plottable destruction

### DIFF
--- a/src/datasource/async-pipeline.cpp
+++ b/src/datasource/async-pipeline.cpp
@@ -21,13 +21,16 @@ QCPAsyncPipelineBase::QCPAsyncPipelineBase(QCPPipelineScheduler* scheduler,
                                              QObject* parent)
     : QObject(parent)
     , mScheduler(scheduler)
-    , mDestroyed(std::make_shared<std::atomic<bool>>(false))
+    , mDestroyGuard(std::make_shared<DestroyGuard>())
 {
 }
 
 QCPAsyncPipelineBase::~QCPAsyncPipelineBase()
 {
-    mDestroyed->store(true);
+    // Taken under the guard mutex so no job sits between its destroyed-check
+    // and its invokeMethod on this object (see makeJob).
+    QMutexLocker lock(&mDestroyGuard->mutex);
+    mDestroyGuard->destroyed = true;
 }
 
 bool QCPAsyncPipelineBase::isBusy() const
@@ -109,9 +112,8 @@ void QCPAsyncPipelineBase::onViewportChanged(const ViewportParams& vp)
 void QCPAsyncPipelineBase::deliverResult(uint64_t generation, std::any cache, std::any result)
 {
     PROFILE_HERE_N("Pipeline::deliverResult");
-    if (mDestroyed->load())
-        return;
-
+    // No destroyed-check needed: this only runs as a queued metacall on a live
+    // object (Qt purges pending metacalls when the receiver is deleted).
     QMutexLocker lock(&mMutex);
     mCache = std::move(cache);
 

--- a/src/datasource/async-pipeline.h
+++ b/src/datasource/async-pipeline.h
@@ -70,7 +70,15 @@ protected:
     ViewportParams mLastViewport;
     bool mWasBusy = false;
 
-    std::shared_ptr<std::atomic<bool>> mDestroyed;
+    // Shared between the pipeline and its in-flight jobs. The destructor flips
+    // `destroyed` under the mutex and jobs hold the mutex across their
+    // check-and-invoke, so the pipeline cannot be deleted between a job's
+    // destroyed-check and its QMetaObject::invokeMethod on `this`.
+    struct DestroyGuard {
+        QMutex mutex;
+        bool destroyed = false;
+    };
+    std::shared_ptr<DestroyGuard> mDestroyGuard;
 
 public:
     // Only safe to call from the pipeline's thread when no job is running
@@ -166,13 +174,19 @@ protected:
 
         auto source = mSource; // shared_ptr copy — keeps source alive for the job
         auto transform = mTransform;
-        auto destroyed = mDestroyed;
+        auto guard = mDestroyGuard;
         auto* self = this;
 
         return [source, transform, vp, cache = std::move(cache),
-                generation, destroyed, self]() mutable {
+                generation, guard, self]() mutable {
             auto result = transform(*source, vp, cache);
-            if (destroyed->load()) return;
+
+            // Held across check + invoke: the destructor takes the same mutex
+            // before flipping `destroyed`, so `self` cannot die in between.
+            // Once invokeMethod has posted, Qt purges the pending metacall if
+            // the receiver is deleted before delivery.
+            QMutexLocker lock(&guard->mutex);
+            if (guard->destroyed) return;
 
             QMetaObject::invokeMethod(self, [self, result = std::move(result),
                                               cache = std::move(cache), generation]() mutable {

--- a/src/datasource/pipeline-scheduler.cpp
+++ b/src/datasource/pipeline-scheduler.cpp
@@ -13,12 +13,23 @@ QCPPipelineScheduler::QCPPipelineScheduler(int maxThreads, QObject* parent)
 
 QCPPipelineScheduler::~QCPPipelineScheduler()
 {
+    // Queued jobs belong to plottables that may already be deleted by the time
+    // the scheduler dies (~QCustomPlot destroys plottables first): drop them
+    // before joining, otherwise a finishing task's epilogue would start them.
+    {
+        QMutexLocker lock(&mMutex);
+        mShuttingDown = true;
+        mFastQueue.clear();
+        mHeavyQueue.clear();
+    }
     mPool.waitForDone();
 }
 
 void QCPPipelineScheduler::submit(Priority priority, std::function<void()> work)
 {
     QMutexLocker lock(&mMutex);
+    if (mShuttingDown)
+        return;
     if (priority == Fast)
         mFastQueue.push_back(std::move(work));
     else
@@ -31,6 +42,8 @@ void QCPPipelineScheduler::submit(Priority priority, std::function<void()> work)
 void QCPPipelineScheduler::scheduleNext()
 {
     QMutexLocker lock(&mMutex);
+    if (mShuttingDown)
+        return;
     while (mRunning < mPool.maxThreadCount())
     {
         std::function<void()> work;

--- a/src/datasource/pipeline-scheduler.h
+++ b/src/datasource/pipeline-scheduler.h
@@ -28,4 +28,5 @@ private:
     std::deque<std::function<void()>> mFastQueue;
     std::deque<std::function<void()>> mHeavyQueue;
     int mRunning = 0;
+    bool mShuttingDown = false;
 };

--- a/src/plottables/plottable-colormap2.cpp
+++ b/src/plottables/plottable-colormap2.cpp
@@ -115,7 +115,11 @@ void QCPColorMap2::setGapThreshold(double threshold)
         return;
     mGapThreshold = threshold;
     installResampleTransform();
-    mPipeline.onDataChanged(); // re-resample so the new threshold shows now, not on the next pan
+    // Re-resample so the new threshold shows now, not on the next pan. Without
+    // a source there is no job to run and onDataChanged() would bump the
+    // pipeline generation for nothing, leaving isBusy() stuck true.
+    if (mDataSource)
+        mPipeline.onDataChanged();
 }
 
 void QCPColorMap2::setDataSource(std::unique_ptr<QCPAbstractDataSource2D> source)

--- a/src/plottables/plottable-colormap2.cpp
+++ b/src/plottables/plottable-colormap2.cpp
@@ -15,8 +15,44 @@ QCPColorMap2::QCPColorMap2(QCPAxis* keyAxis, QCPAxis* valueAxis)
     , mPipeline(parentPlot() ? parentPlot()->pipelineScheduler() : nullptr, this)
     , mRenderer(this)
 {
+    installResampleTransform();
+
+    if (keyAxis)
+    {
+        connect(keyAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged),
+                this, &QCPColorMap2::onViewportChanged);
+    }
+    if (valueAxis)
+    {
+        connect(valueAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged),
+                this, &QCPColorMap2::onViewportChanged);
+        connect(valueAxis, &QCPAxis::scaleTypeChanged,
+                this, [this](QCPAxis::ScaleType) { onViewportChanged(); });
+    }
+
+    connect(&mPipeline, &QCPColormapPipeline::finished,
+            this, [this](uint64_t) {
+                ++mContourDataGen;
+                mRenderer.invalidateMapImage();
+                if (parentPlot())
+                    parentPlot()->replot(QCustomPlot::rpQueuedReplot);
+            });
+    connect(&mPipeline, &QCPColormapPipeline::busyChanged,
+            this, [this](bool) { updateEffectiveBusy(); });
+}
+
+QCPColorMap2::~QCPColorMap2()
+{
+    mRenderer.releaseRhiLayer();
+}
+
+// The transform runs on the scheduler's pool, possibly after this plottable is
+// deleted (queued jobs are not joined with destruction) — it must be
+// self-contained: settings are captured BY VALUE and re-baked when they change.
+void QCPColorMap2::installResampleTransform()
+{
     mPipeline.setTransform(TransformKind::ViewportDependent,
-        [&gapThreshold = mGapThreshold](
+        [gapThreshold = mGapThreshold](
             const QCPAbstractDataSource2D& src,
             const ViewportParams& vp,
             std::any& cache) -> std::shared_ptr<QCPColorMapData> {
@@ -68,37 +104,18 @@ QCPColorMap2::QCPColorMap2(QCPAxis* keyAxis, QCPAxis* valueAxis)
                 cache = qcp::algo2d::ResampleCache{};
             auto& rc = std::any_cast<qcp::algo2d::ResampleCache&>(cache);
             auto* raw = qcp::algo2d::resample(src, xBegin, xEnd,
-                xOut, yOut, w, h, vp.valueLogScale, gapThreshold.load(std::memory_order_relaxed), &rc);
+                xOut, yOut, w, h, vp.valueLogScale, gapThreshold, &rc);
             return std::shared_ptr<QCPColorMapData>(raw);
         });
-
-    if (keyAxis)
-    {
-        connect(keyAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged),
-                this, &QCPColorMap2::onViewportChanged);
-    }
-    if (valueAxis)
-    {
-        connect(valueAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged),
-                this, &QCPColorMap2::onViewportChanged);
-        connect(valueAxis, &QCPAxis::scaleTypeChanged,
-                this, [this](QCPAxis::ScaleType) { onViewportChanged(); });
-    }
-
-    connect(&mPipeline, &QCPColormapPipeline::finished,
-            this, [this](uint64_t) {
-                ++mContourDataGen;
-                mRenderer.invalidateMapImage();
-                if (parentPlot())
-                    parentPlot()->replot(QCustomPlot::rpQueuedReplot);
-            });
-    connect(&mPipeline, &QCPColormapPipeline::busyChanged,
-            this, [this](bool) { updateEffectiveBusy(); });
 }
 
-QCPColorMap2::~QCPColorMap2()
+void QCPColorMap2::setGapThreshold(double threshold)
 {
-    mRenderer.releaseRhiLayer();
+    if (mGapThreshold == threshold)
+        return;
+    mGapThreshold = threshold;
+    installResampleTransform();
+    mPipeline.onDataChanged(); // re-resample so the new threshold shows now, not on the next pan
 }
 
 void QCPColorMap2::setDataSource(std::unique_ptr<QCPAbstractDataSource2D> source)

--- a/src/plottables/plottable-colormap2.h
+++ b/src/plottables/plottable-colormap2.h
@@ -54,8 +54,8 @@ public:
     }
 
     // Properties
-    void setGapThreshold(double threshold) { mGapThreshold.store(threshold, std::memory_order_relaxed); }
-    [[nodiscard]] double gapThreshold() const { return mGapThreshold.load(std::memory_order_relaxed); }
+    void setGapThreshold(double threshold);
+    [[nodiscard]] double gapThreshold() const { return mGapThreshold; }
 
     [[nodiscard]] QCPColorGradient gradient() const { return mRenderer.gradient(); }
     [[nodiscard]] QCPColorScale* colorScale() const { return mRenderer.colorScale(); }
@@ -105,8 +105,12 @@ protected:
     void releaseGpuResources() override { mRenderer.releaseRhiLayer(); }
 
 private:
+    void installResampleTransform();
+
     std::shared_ptr<QCPAbstractDataSource2D> mDataSource;
-    std::atomic<double> mGapThreshold{1.5}; // before mPipeline: must outlive background jobs
+    // Captured by value in the pipeline transform (re-baked by setGapThreshold)
+    // so background jobs never reference this object's memory.
+    double mGapThreshold = 1.5;
     QCPColormapPipeline mPipeline;
     QCPColormapRenderer mRenderer;
 

--- a/tests/auto/test-datasource2d/test-datasource2d.cpp
+++ b/tests/auto/test-datasource2d/test-datasource2d.cpp
@@ -712,6 +712,11 @@ void TestDataSource2D::colormap2ViewData()
     QVERIFY(cm->dataSource() != nullptr);
     QCOMPARE(cm->dataSource()->xSize(), 2);
     QCOMPARE(cm->dataSource()->ySize(), 3);
+
+    // Non-owning views over stack arrays: viewData kicked an async resample
+    // that reads them on the pool — drain the pipeline before this frame dies
+    // (caught by ASan as stack-use-after-return).
+    QTRY_VERIFY_WITH_TIMEOUT(!cm->pipeline().isBusy(), 5000);
 }
 
 void TestDataSource2D::colormap2Render()

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -650,6 +650,16 @@ void TestPipeline::colormap2QueuedJobAfterDeleteDoesNotTouchFreedMemory()
     QThread::msleep(200); // let the orphaned job run (or be dropped, post-fix)
 }
 
+void TestPipeline::colormap2GapThresholdBeforeDataDoesNotStickBusy()
+{
+    // setGapThreshold() triggers a re-resample, but before any data source is
+    // set there is no job to run: onDataChanged() must not bump the pipeline
+    // generation, or isBusy() reports true until some future job delivers.
+    auto* cm = new QCPColorMap2(mPlot->xAxis, mPlot->yAxis);
+    cm->setGapThreshold(5.0);
+    QVERIFY(!cm->pipeline().isBusy());
+}
+
 // --- Graph resampler tests ---
 
 void TestPipeline::graphResamplerBinMinMax()

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -16,6 +16,7 @@
 #include <plottables/plottable-waterfall.h>
 #include <QSignalSpy>
 #include <QThread>
+#include <thread>
 #include <QtWidgets/qtestsupport_widgets.h> // QTest::qWaitForWindowExposed
 #include <cmath>
 #include <limits>
@@ -593,6 +594,60 @@ void TestPipeline::pipelineRapidFireDeliverResult()
     QTRY_VERIFY_WITH_TIMEOUT(spy.count() >= 1, 3000);
     QVERIFY(pipeline.result() != nullptr);
     QCOMPARE(pipeline.result()->size(), 3);
+}
+
+void TestPipeline::schedulerDtorDropsQueuedJobs()
+{
+    // Jobs still queued when the scheduler dies belong to plottables that may
+    // already be destroyed — the destructor must drop them, not run them
+    // (waitForDone lets a finishing task's epilogue start queued work).
+    std::atomic<bool> gate{false};
+    std::atomic<bool> started{false};
+    std::atomic<bool> queuedRan{false};
+    std::thread releaser;
+    {
+        QCPPipelineScheduler scheduler(1);
+        scheduler.submit(QCPPipelineScheduler::Heavy, [&] {
+            started.store(true);
+            while (!gate.load()) QThread::msleep(2);
+        });
+        while (!started.load()) QThread::msleep(2);
+        scheduler.submit(QCPPipelineScheduler::Heavy, [&] { queuedRan.store(true); });
+        releaser = std::thread([&] {
+            QThread::msleep(100);
+            gate.store(true);
+        });
+        // ~QCPPipelineScheduler runs here: drop the queued job, join the blocker
+    }
+    releaser.join();
+    QVERIFY(!queuedRan.load());
+}
+
+void TestPipeline::colormap2QueuedJobAfterDeleteDoesNotTouchFreedMemory()
+{
+    // The colormap resample transform used to capture the member mGapThreshold
+    // by reference; a job dequeued after removePlottable() then read freed
+    // memory. Fails under ASan before the fix (silent in a plain build).
+    auto* scheduler = mPlot->pipelineScheduler();
+    const int threads = scheduler->maxThreads();
+    std::atomic<bool> gate{false};
+    std::atomic<int> started{0};
+    for (int i = 0; i < threads; ++i)
+        scheduler->submit(QCPPipelineScheduler::Heavy, [&] {
+            started.fetch_add(1);
+            while (!gate.load()) QThread::msleep(2);
+        });
+    while (started.load() < threads) QThread::msleep(2);
+
+    auto* cm = new QCPColorMap2(mPlot->xAxis, mPlot->yAxis);
+    std::vector<double> x = {0, 1, 2};
+    std::vector<double> y = {0, 1};
+    std::vector<double> z = {1, 2, 3, 4, 5, 6};
+    cm->setData(std::move(x), std::move(y), std::move(z)); // job queued behind blockers
+    QVERIFY(mPlot->removePlottable(cm)); // deletes the colormap; its job is still queued
+
+    gate.store(true);
+    QThread::msleep(200); // let the orphaned job run (or be dropped, post-fix)
 }
 
 // --- Graph resampler tests ---

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -43,6 +43,7 @@ private slots:
     void pipelineRapidFireDeliverResult();
     void schedulerDtorDropsQueuedJobs();
     void colormap2QueuedJobAfterDeleteDoesNotTouchFreedMemory();
+    void colormap2GapThresholdBeforeDataDoesNotStickBusy();
 
     // Graph resampler
     void graphResamplerBinMinMax();

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -41,6 +41,8 @@ private slots:
     // Race condition reproducers
     void pipelineSourceReplacedDuringJob();
     void pipelineRapidFireDeliverResult();
+    void schedulerDtorDropsQueuedJobs();
+    void colormap2QueuedJobAfterDeleteDoesNotTouchFreedMemory();
 
     // Graph resampler
     void graphResamplerBinMinMax();

--- a/tests/auto/test-scatter-rhi/test-scatter-rhi.cpp
+++ b/tests/auto/test-scatter-rhi/test-scatter-rhi.cpp
@@ -86,7 +86,9 @@ static QCPGraph2* addGraph2WithScatter(QCustomPlot* plot,
         keys[i] = i;
         values[i] = std::sin(i * 0.1);
     }
-    graph->setData(std::span<const double>(keys), std::span<const double>(values));
+    // Owning setData: span views over these locals would dangle after return
+    // (caught by ASan as heap-use-after-free in the next draw).
+    graph->setData(std::move(keys), std::move(values));
     plot->xAxis->setRange(0, nPoints);
     plot->yAxis->setRange(-1.5, 1.5);
     return graph;


### PR DESCRIPTION
Three holes let resample jobs touch freed memory when a plottable (or the whole QCustomPlot) died with work in flight — the typical "random crash when closing a plot during a spectrogram resample":

- **QCPColorMap2's transform captured the member `mGapThreshold` by reference**; a job dequeued after the plottable was deleted read freed memory. The transform is now installed by `installResampleTransform()` with the threshold captured **by value** and re-baked by `setGapThreshold()` (mirroring `QCPHistogram2D::installTransform`). Bonus: a threshold change now triggers a re-resample instead of silently waiting for the next pan.

- **TOCTOU in the job epilogue**: `if (destroyed->load()) return; invokeMethod(self, ...)` — the pipeline could be deleted between the load and the invoke. The shared atomic is replaced by a mutex-guarded flag held across the check-and-invoke; `~QCPAsyncPipelineBase` flips it under the same mutex. Once posted, Qt purges pending metacalls of a deleted receiver, so the queued delivery is safe.

- **`~QCPPipelineScheduler` let `waitForDone()` start still-queued jobs** (a finishing task's epilogue drains the queue) — jobs belonging to plottables already destroyed by `~QCustomPlot`. The destructor now drops queued work and refuses new submissions before joining.

**Reproducers** (fail before the fix):
- `TestPipeline::colormap2QueuedJobAfterDeleteDoesNotTouchFreedMemory` — ASan heap-use-after-free in the gapThreshold load; the pre-existing `TestDataSource2D::colormap2AxisRescale` also tripped it via plain `~QCustomPlot` teardown under ASan.
- `TestPipeline::schedulerDtorDropsQueuedJobs` — queued job ran during destruction (deterministic, no sanitizer needed).

Also fixes two test-side dangling-view bugs found by the ASan run (`colormap2ViewData` returning while the job reads stack spans; test-scatter-rhi spans over helper-local vectors). Full suite is ASan-clean after this commit.

Part of the 2026-06-09 audit (C2/C3 in SciQLopPlots `docs/backlog-2026-06-10.md`). First of a 4-PR stack: this → waterfall snapshot → range scans → small sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)