### PR TITLE
fix(waterfall): immutable per-generation adapter — no more racing in-flight jobs or stale draws

### DIFF
--- a/src/plottables/plottable-waterfall.cpp
+++ b/src/plottables/plottable-waterfall.cpp
@@ -134,7 +134,13 @@ void QCPWaterfallGraph::recomputeNormFactors()
 void QCPWaterfallGraph::rebuildAdapter()
 {
     if (!mOriginalSource)
+    {
+        // Clearing the source must uninstall the previous adapter too, or the
+        // graph keeps rendering the old data (base caches stay populated).
+        mAdapter.reset();
+        QCPMultiGraph::setDataSource(std::shared_ptr<QCPAbstractMultiDataSource>{});
         return;
+    }
     if (mNormDirty)
         recomputeNormFactors();
 

--- a/src/plottables/plottable-waterfall.cpp
+++ b/src/plottables/plottable-waterfall.cpp
@@ -4,14 +4,13 @@
 // --- QCPWaterfallDataAdapter ---
 
 QCPWaterfallDataAdapter::QCPWaterfallDataAdapter(
-    std::shared_ptr<QCPAbstractMultiDataSource> source)
+    std::shared_ptr<QCPAbstractMultiDataSource> source,
+    QVector<double> offsets, QVector<double> normFactors, double gain)
     : mSource(std::move(source))
+    , mOffsets(std::move(offsets))
+    , mNormFactors(std::move(normFactors))
+    , mGain(gain)
 {
-}
-
-void QCPWaterfallDataAdapter::setSource(std::shared_ptr<QCPAbstractMultiDataSource> source)
-{
-    mSource = std::move(source);
 }
 
 int QCPWaterfallDataAdapter::columnCount() const { return mSource ? mSource->columnCount() : 0; }
@@ -86,24 +85,22 @@ QVector<QPointF> QCPWaterfallDataAdapter::getOptimizedLineData(int column, int b
 
 QCPWaterfallGraph::QCPWaterfallGraph(QCPAxis* keyAxis, QCPAxis* valueAxis)
     : QCPMultiGraph(keyAxis, valueAxis)
-    , mAdapter(std::make_shared<QCPWaterfallDataAdapter>(nullptr))
 {
 }
 
 void QCPWaterfallGraph::setDataSource(std::shared_ptr<QCPAbstractMultiDataSource> source)
 {
     mOriginalSource = std::move(source);
-    mAdapter->setSource(mOriginalSource);
     mNormDirty = true;
-    QCPMultiGraph::setDataSource(mAdapter);
+    rebuildAdapter();
 }
 
-void QCPWaterfallGraph::setOffsetMode(OffsetMode mode) { mOffsetMode = mode; }
-void QCPWaterfallGraph::setUniformSpacing(double spacing) { mUniformSpacing = spacing; }
-void QCPWaterfallGraph::setOffsets(const QVector<double>& offsets) { mUserOffsets = offsets; }
-void QCPWaterfallGraph::setNormalize(bool enabled) { mNormalize = enabled; mNormDirty = true; }
-void QCPWaterfallGraph::setGain(double gain) { mGain = gain; }
-void QCPWaterfallGraph::invalidateNormalization() { mNormDirty = true; }
+void QCPWaterfallGraph::setOffsetMode(OffsetMode mode) { mOffsetMode = mode; rebuildAdapter(); }
+void QCPWaterfallGraph::setUniformSpacing(double spacing) { mUniformSpacing = spacing; rebuildAdapter(); }
+void QCPWaterfallGraph::setOffsets(const QVector<double>& offsets) { mUserOffsets = offsets; rebuildAdapter(); }
+void QCPWaterfallGraph::setNormalize(bool enabled) { mNormalize = enabled; mNormDirty = true; rebuildAdapter(); }
+void QCPWaterfallGraph::setGain(double gain) { mGain = gain; rebuildAdapter(); }
+void QCPWaterfallGraph::invalidateNormalization() { mNormDirty = true; rebuildAdapter(); }
 
 double QCPWaterfallGraph::effectiveOffset(int component) const
 {
@@ -112,7 +109,7 @@ double QCPWaterfallGraph::effectiveOffset(int component) const
     return component * mUniformSpacing;
 }
 
-void QCPWaterfallGraph::recomputeNormFactors() const
+void QCPWaterfallGraph::recomputeNormFactors()
 {
     if (!mOriginalSource) {
         mCachedNormFactors.clear();
@@ -134,9 +131,10 @@ void QCPWaterfallGraph::recomputeNormFactors() const
     mNormDirty = false;
 }
 
-void QCPWaterfallGraph::updateAdapter() const
+void QCPWaterfallGraph::rebuildAdapter()
 {
-    if (!mOriginalSource) return;
+    if (!mOriginalSource)
+        return;
     if (mNormDirty)
         recomputeNormFactors();
 
@@ -145,21 +143,19 @@ void QCPWaterfallGraph::updateAdapter() const
     for (int c = 0; c < cols; ++c)
         offsets[c] = effectiveOffset(c);
 
-    mAdapter->setOffsets(offsets);
-    mAdapter->setNormFactors(mCachedNormFactors);
-    mAdapter->setGain(mGain);
+    mAdapter = std::make_shared<QCPWaterfallDataAdapter>(
+        mOriginalSource, std::move(offsets), mCachedNormFactors, mGain);
+    QCPMultiGraph::setDataSource(mAdapter);
 }
 
 void QCPWaterfallGraph::dataChanged()
 {
-    invalidateNormalization();
+    // In-place mutation of the inner source: norm factors are stale, snapshot
+    // a fresh adapter (which also invalidates line/L1/L2 caches) before the
+    // base handles the change.
+    mNormDirty = true;
+    rebuildAdapter();
     QCPMultiGraph::dataChanged();
-}
-
-void QCPWaterfallGraph::draw(QCPPainter* painter)
-{
-    updateAdapter();
-    QCPMultiGraph::draw(painter);
 }
 
 QCPRange QCPWaterfallGraph::getValueRange(bool& foundRange,
@@ -171,7 +167,6 @@ QCPRange QCPWaterfallGraph::getValueRange(bool& foundRange,
         return QCPRange();
 
     if (inKeyRange != QCPRange()) {
-        updateAdapter();
         QCPRange merged;
         bool first = true;
         for (int c = 0; c < mOriginalSource->columnCount(); ++c) {

--- a/src/plottables/plottable-waterfall.h
+++ b/src/plottables/plottable-waterfall.h
@@ -2,16 +2,17 @@
 #include "plottable-multigraph.h"
 #include <memory>
 
+// Immutable snapshot: built whole, never mutated. Async resample jobs hold a
+// shared_ptr to one generation while the graph swaps in the next — like the
+// SoA sources, the adapter co-owns its inner source so an in-flight job can
+// never observe a parameter change, a source swap, or a freed source.
 class QCPWaterfallDataAdapter : public QCPAbstractMultiDataSource {
 public:
-    explicit QCPWaterfallDataAdapter(std::shared_ptr<QCPAbstractMultiDataSource> source);
+    QCPWaterfallDataAdapter(std::shared_ptr<QCPAbstractMultiDataSource> source,
+                            QVector<double> offsets, QVector<double> normFactors,
+                            double gain);
 
-    void setSource(std::shared_ptr<QCPAbstractMultiDataSource> source);
     QCPAbstractMultiDataSource* source() const { return mSource.get(); }
-
-    void setOffsets(const QVector<double>& offsets) { mOffsets = offsets; }
-    void setNormFactors(const QVector<double>& factors) { mNormFactors = factors; }
-    void setGain(double gain) { mGain = gain; }
 
     int columnCount() const override;
     int size() const override;
@@ -29,10 +30,10 @@ public:
                                            QCPAxis* keyAxis, QCPAxis* valueAxis) const override;
 
 private:
-    std::shared_ptr<QCPAbstractMultiDataSource> mSource;
-    QVector<double> mOffsets;
-    QVector<double> mNormFactors;
-    double mGain = 1.0;
+    const std::shared_ptr<QCPAbstractMultiDataSource> mSource;
+    const QVector<double> mOffsets;
+    const QVector<double> mNormFactors;
+    const double mGain;
 
     double transform(int column, double rawValue) const;
 };
@@ -63,7 +64,6 @@ public:
 
 protected:
     void dataChanged() override;
-    void draw(QCPPainter* painter) override;
     QCPRange getValueRange(bool& foundRange,
                            QCP::SignDomain inSignDomain = QCP::sdBoth,
                            const QCPRange& inKeyRange = QCPRange()) const override;
@@ -74,15 +74,19 @@ private:
     QVector<double> mUserOffsets;
     bool mNormalize = true;
     double mGain = 1.0;
-    mutable bool mNormDirty = true;
-    mutable QVector<double> mCachedNormFactors;
+    bool mNormDirty = true;
+    QVector<double> mCachedNormFactors;
 
     std::shared_ptr<QCPAbstractMultiDataSource> mOriginalSource;
     std::shared_ptr<QCPWaterfallDataAdapter> mAdapter;
 
     double effectiveOffset(int component) const;
-    void updateAdapter() const;
-    void recomputeNormFactors() const;
+    // Builds a fresh immutable adapter and pushes it through
+    // QCPMultiGraph::setDataSource — every data/parameter change goes through
+    // here, so line/L1/L2 caches are invalidated and what is drawn always
+    // matches the current parameters.
+    void rebuildAdapter();
+    void recomputeNormFactors();
 
     friend class TestWaterfall;
 };

--- a/tests/auto/test-waterfall/test-waterfall.cpp
+++ b/tests/auto/test-waterfall/test-waterfall.cpp
@@ -315,3 +315,21 @@ void TestWaterfall::concurrentParameterAndDataChangesAreSafe()
     // drain in-flight jobs before the plot dies
     QTRY_VERIFY_WITH_TIMEOUT(!wf->pipeline().isBusy(), 10000);
 }
+
+void TestWaterfall::clearingSourceEmptiesTheGraph()
+{
+    // rebuildAdapter() used to early-return on a null source, leaving the
+    // previous adapter installed in QCPMultiGraph: the graph kept rendering
+    // the old data while getKeyRange() already reported "no data".
+    auto* wf = new QCPWaterfallGraph(mPlot->xAxis, mPlot->yAxis);
+    std::vector<double> keys = {0.0, 1.0};
+    std::vector<std::vector<double>> vals = {{1.0, 2.0}};
+    wf->setData(std::move(keys), std::move(vals));
+    QVERIFY(wf->dataSource() != nullptr);
+
+    wf->setDataSource(nullptr);
+    QCOMPARE(wf->dataSource(), nullptr);
+    bool found = true;
+    wf->getKeyRange(found);
+    QVERIFY(!found);
+}

--- a/tests/auto/test-waterfall/test-waterfall.cpp
+++ b/tests/auto/test-waterfall/test-waterfall.cpp
@@ -1,5 +1,7 @@
 #include "test-waterfall.h"
 #include "../../../src/qcp.h"
+#include <QCoreApplication>
+#include <cmath>
 
 void TestWaterfall::init()
 {
@@ -257,4 +259,59 @@ void TestWaterfall::drawDoesNotCrash()
 
     new QCPWaterfallGraph(mPlot->xAxis, mPlot->yAxis);
     mPlot->replot(QCustomPlot::rpImmediateRefresh);
+}
+
+void TestWaterfall::parameterChangesApplyWithoutDraw()
+{
+    // Gain/offset/normalize changes must be visible in the data source
+    // immediately — not only after the next draw() happened to refresh the
+    // shared adapter (stale-draw bug: the line cache redrew old amplitudes
+    // while autoscale already used the new ones).
+    auto* wf = new QCPWaterfallGraph(mPlot->xAxis, mPlot->yAxis);
+    wf->setOffsetMode(QCPWaterfallGraph::omUniform);
+    wf->setUniformSpacing(0.0);
+    wf->setNormalize(false);
+    wf->setGain(1.0);
+
+    std::vector<double> keys = {0.0, 1.0};
+    std::vector<std::vector<double>> vals = {{1.0, 2.0}};
+    wf->setData(std::move(keys), std::move(vals));
+
+    QCOMPARE(wf->dataSource()->valueAt(0, 0), 1.0);
+
+    wf->setGain(3.0);
+    QCOMPARE(wf->dataSource()->valueAt(0, 0), 3.0);
+
+    wf->setOffsetMode(QCPWaterfallGraph::omCustom);
+    wf->setOffsets({10.0});
+    QCOMPARE(wf->dataSource()->valueAt(0, 0), 13.0);
+}
+
+void TestWaterfall::concurrentParameterAndDataChangesAreSafe()
+{
+    // Data and parameter changes while L1 resample jobs are in flight must
+    // never mutate state those jobs read (shared adapter members, inner
+    // source swap) — pre-fix this is a data race / UAF caught by ASan.
+    constexpr int n = 80'000; // x2 columns > kResampleThreshold
+    auto* wf = new QCPWaterfallGraph(mPlot->xAxis, mPlot->yAxis);
+    wf->setNormalize(true);
+
+    for (int iter = 0; iter < 10; ++iter)
+    {
+        std::vector<double> keys(n);
+        std::vector<std::vector<double>> vals(2, std::vector<double>(n));
+        for (int i = 0; i < n; ++i)
+        {
+            keys[i] = i;
+            vals[0][i] = std::sin(i * 0.001) * (iter + 1);
+            vals[1][i] = std::cos(i * 0.001) * (iter + 1);
+        }
+        wf->setData(std::move(keys), std::move(vals)); // kicks an L1 job
+        wf->setGain(1.0 + iter);                        // raced the job pre-fix
+        wf->setUniformSpacing(2.0 + iter);
+        mPlot->replot(QCustomPlot::rpImmediateRefresh); // draw raced it too
+        QCoreApplication::processEvents();
+    }
+    // drain in-flight jobs before the plot dies
+    QTRY_VERIFY_WITH_TIMEOUT(!wf->pipeline().isBusy(), 10000);
 }

--- a/tests/auto/test-waterfall/test-waterfall.h
+++ b/tests/auto/test-waterfall/test-waterfall.h
@@ -26,6 +26,11 @@ private slots:
 
     void drawDoesNotCrash();
 
+    // Snapshot semantics (C4/H6): parameters apply without waiting for a draw,
+    // and concurrent data/parameter changes never race in-flight resample jobs.
+    void parameterChangesApplyWithoutDraw();
+    void concurrentParameterAndDataChangesAreSafe();
+
 private:
     QCustomPlot* mPlot = nullptr;
 };

--- a/tests/auto/test-waterfall/test-waterfall.h
+++ b/tests/auto/test-waterfall/test-waterfall.h
@@ -30,6 +30,7 @@ private slots:
     // and concurrent data/parameter changes never race in-flight resample jobs.
     void parameterChangesApplyWithoutDraw();
     void concurrentParameterAndDataChangesAreSafe();
+    void clearingSourceEmptiesTheGraph();
 
 private:
     QCustomPlot* mPlot = nullptr;


### PR DESCRIPTION
> **Stacked on #32** — merge that first; this PR's diff then collapses to its own commit (`6ab2e66`).

QCPWaterfallGraph was the one plottable that broke the pipeline's immutable-snapshot contract: it handed the resampler a single long-lived mutable `QCPWaterfallDataAdapter`, then mutated it freely — `draw()` reassigned offsets/norm-factors/gain on every paint and `setDataSource()` swapped the inner source, all while pool jobs read those members through `keyAt()`/`valueAt()`. Two user-visible consequences:

- **data race / use-after-free**: an L1 build mid-iteration could observe a half-written QVector or keep iterating an inner source that new data had just destroyed (the job's shared_ptr kept only the adapter alive, not the source);
- **stale draws**: `setGain`/`setOffsets`/`setNormalize` invalidated no cache, so a parameter change was a visual no-op until something else dirtied the line cache — while autoscale (`getValueRange`, which DID refresh the adapter) already used the new value, drawing lines inconsistent with the axis range.

The adapter is now an immutable snapshot (const members; co-owns its inner source) and `QCPWaterfallGraph::rebuildAdapter()` builds a fresh one on every data or parameter change, pushing it through `QCPMultiGraph::setDataSource` — which already invalidates line/L1/L2 caches. `draw()` no longer mutates anything; in-flight jobs finish against their own generation.

**Reproducers**: `TestWaterfall::parameterChangesApplyWithoutDraw` (failed before: gain changes were invisible to the data source until the next draw) and `TestWaterfall::concurrentParameterAndDataChangesAreSafe` (ASan regression guard hammering data+parameter changes against in-flight L1 jobs; the race is timing-dependent, so this guards rather than proves). Full suite ASan-clean; all 15 waterfall tests pass.

Part of the 2026-06-09 audit (C4/H6 — one design fix covers both). Stack: #32 → **this** → range scans → small sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)