### PR TITLE
fix(resample): NaN handling in adaptive sampling + L1 validity on same-size replacement

### DIFF
--- a/src/datasource/algorithms-2d.h
+++ b/src/datasource/algorithms-2d.h
@@ -21,7 +21,8 @@ int findXEnd(const XC& x, double sortKey)
 template <IndexableNumericRange XC>
 QCPRange xRange(const XC& x, bool& found, QCP::SignDomain sd = QCP::sdBoth)
 {
-    return qcp::algo::keyRange(x, found, sd);
+    // x columns are sorted (2D source contract) — O(1)/O(log n) range
+    return qcp::algo::keyRangeSorted(x, found, sd);
 }
 
 template <IndexableNumericRange YC>

--- a/src/datasource/algorithms.h
+++ b/src/datasource/algorithms.h
@@ -150,16 +150,21 @@ QCPRange valueRange(const KC& keys, const VC& values, bool& foundRange,
     const bool hasKeyRestriction = inKeyRange.lower != inKeyRange.upper
                                     || inKeyRange.lower != 0.0;
 
+    // Keys are sorted (data source contract): restrict the scan to the visible
+    // window via binary search instead of testing every key. Callers with
+    // unsorted keys (histogram scatter) must not pass a key restriction here.
+    int i0 = 0;
+    int i1 = sz;
+    if (hasKeyRestriction)
+    {
+        i0 = findBegin(keys, inKeyRange.lower, false);
+        i1 = findEnd(keys, inKeyRange.upper, false);
+    }
+
     double lower = std::numeric_limits<double>::max();
     double upper = std::numeric_limits<double>::lowest();
-    for (int i = 0; i < sz; ++i)
+    for (int i = i0; i < i1; ++i)
     {
-        if (hasKeyRestriction)
-        {
-            double k = static_cast<double>(keys[i]);
-            if (k < inKeyRange.lower || k > inKeyRange.upper)
-                continue;
-        }
         double v = static_cast<double>(values[i]);
         if (sd == QCP::sdPositive && v <= 0) continue;
         if (sd == QCP::sdNegative && v >= 0) continue;

--- a/src/datasource/algorithms.h
+++ b/src/datasource/algorithms.h
@@ -337,7 +337,11 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
                           : QPointF(keyAxis->coordToPixel(k), valueAxis->coordToPixel(v));
     };
 
-    auto flushInterval = [&](int intervalFirst, int intervalCount,
+    // intervalLast is the index of the last ACCEPTED (non-NaN) sample: NaN
+    // samples are skipped without counting, so deriving the closing point as
+    // intervalFirst + intervalCount - 1 could land on a NaN and inject a
+    // spurious line break into gap-free data.
+    auto flushInterval = [&](int intervalFirst, int intervalLast, int intervalCount,
                               double intervalStartKey, double lastEndKey,
                               double minVal, double maxVal,
                               double epsilon, double nextKey) {
@@ -350,9 +354,8 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
             result.append(toPixel(intervalStartKey + epsilon * 0.75, maxVal));
             if (nextKey > intervalStartKey + epsilon * 2)
             {
-                int prev = intervalFirst + intervalCount - 1;
                 result.append(toPixel(intervalStartKey + epsilon * 0.8,
-                                       static_cast<double>(values[prev])));
+                                       static_cast<double>(values[intervalLast])));
             }
         }
         else
@@ -374,6 +377,7 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
     double minValue = static_cast<double>(values[i]);
     double maxValue = minValue;
     int currentIntervalFirst = i;
+    int currentIntervalLast = i;
     int reversedFactor = keyAxis->pixelOrientation();
     int reversedRound = reversedFactor == -1 ? 1 : 0;
 
@@ -425,7 +429,7 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
         if (hasAnyGap && gapData[i - begin])
         {
             double k = static_cast<double>(keys[i]);
-            flushInterval(currentIntervalFirst, intervalDataCount,
+            flushInterval(currentIntervalFirst, currentIntervalLast, intervalDataCount,
                           currentIntervalStartKey, lastIntervalEndKey,
                           minValue, maxValue, keyEpsilon, k);
             result.append(nanPt);
@@ -433,6 +437,7 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
             minValue = v;
             maxValue = v;
             currentIntervalFirst = i;
+            currentIntervalLast = i;
             if (useInlineTransform)
             {
                 int pixel = static_cast<int>(keyTf.toPixel(k)) + reversedRound;
@@ -459,16 +464,18 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
             minValue = std::min(minValue, v);
             maxValue = std::max(maxValue, v);
             ++intervalDataCount;
+            currentIntervalLast = i;
         }
         else
         {
-            flushInterval(currentIntervalFirst, intervalDataCount,
+            flushInterval(currentIntervalFirst, currentIntervalLast, intervalDataCount,
                           currentIntervalStartKey, lastIntervalEndKey,
                           minValue, maxValue, keyEpsilon, k);
             lastIntervalEndKey = static_cast<double>(keys[i - 1]);
             minValue = v;
             maxValue = v;
             currentIntervalFirst = i;
+            currentIntervalLast = i;
             if (useInlineTransform)
             {
                 int pixel = static_cast<int>(keyTf.toPixel(k)) + reversedRound;
@@ -488,7 +495,7 @@ QVector<QPointF> optimizedLineData(const KC& keys, const VC& values,
         }
         ++i;
     }
-    flushInterval(currentIntervalFirst, intervalDataCount,
+    flushInterval(currentIntervalFirst, currentIntervalLast, intervalDataCount,
                   currentIntervalStartKey, lastIntervalEndKey,
                   minValue, maxValue, keyEpsilon,
                   currentIntervalStartKey + keyEpsilon * 3);
@@ -658,11 +665,11 @@ void optimizedLineDataMulti(const KC& keys,
         }
         else
         {
+            // NaN values are skipped (not breaks) on the adaptive path — key
+            // gaps are detected separately; matching the single-column variant.
             double val = valueAt(c, s.intervalFirst);
             if (!std::isnan(val))
                 results[c].append(toPixel(static_cast<double>(keys[s.intervalFirst]), val));
-            else
-                results[c].append(nanPt);
         }
     };
 
@@ -711,8 +718,18 @@ void optimizedLineDataMulti(const KC& keys,
                 double v = valueAt(c, i);
                 if (!std::isnan(v))
                 {
-                    cs[c].minVal = std::min(cs[c].minVal, v);
-                    cs[c].maxVal = std::max(cs[c].maxVal, v);
+                    // a NaN-seeded interval (reset on a NaN sample) must
+                    // re-seed here, or std::min/max stay NaN-poisoned
+                    if (std::isnan(cs[c].minVal))
+                    {
+                        cs[c].minVal = v;
+                        cs[c].maxVal = v;
+                    }
+                    else
+                    {
+                        cs[c].minVal = std::min(cs[c].minVal, v);
+                        cs[c].maxVal = std::max(cs[c].maxVal, v);
+                    }
                 }
                 ++cs[c].intervalCount;
             }

--- a/src/datasource/graph-resampler.h
+++ b/src/datasource/graph-resampler.h
@@ -424,14 +424,17 @@ inline std::shared_ptr<QCPAbstractDataSource> buildL1Cache(
     if (srcSize == 0 || srcSize < kResampleThreshold)
         return nullptr;
 
-    auto* c = std::any_cast<GraphResamplerCache>(&cache);
-    if (c && c->sourceSize == srcSize)
-        return nullptr; // L1 already valid
-
     bool foundRange = false;
     QCPRange fullKeyRange = src.keyRange(foundRange);
     if (!foundRange || fullKeyRange.size() <= 0)
         return nullptr;
+
+    // Same size is not enough: replacing the data with an equally-sized batch
+    // must not reuse a stale L1, so the cached key range participates too
+    // (keyRange is O(1) on sorted sources).
+    auto* c = std::any_cast<GraphResamplerCache>(&cache);
+    if (c && c->sourceSize == srcSize && c->cachedKeyRange == fullKeyRange)
+        return nullptr; // L1 already valid
     int numBins = std::min(kLevel1TargetBins, srcSize / 10);
 
     GraphResamplerCache newCache;
@@ -501,13 +504,14 @@ inline std::shared_ptr<QCPAbstractMultiDataSource> buildL1CacheMulti(
     if (srcSize == 0 || N == 0)
         return nullptr;
 
-    auto* c = std::any_cast<MultiGraphResamplerCache>(&cache);
-    if (c && c->sourceSize == srcSize && c->columnCount == N)
-        return nullptr;
-
     bool foundRange = false;
     QCPRange fullKeyRange = src.keyRange(foundRange);
     if (!foundRange || fullKeyRange.size() <= 0)
+        return nullptr;
+
+    auto* c = std::any_cast<MultiGraphResamplerCache>(&cache);
+    if (c && c->sourceSize == srcSize && c->columnCount == N
+        && c->cachedKeyRange == fullKeyRange)
         return nullptr;
     int numBins = std::min(kLevel1TargetBins, srcSize / 10);
 

--- a/src/datasource/row-major-multi-datasource.h
+++ b/src/datasource/row-major-multi-datasource.h
@@ -118,7 +118,7 @@ public:
 
     QCPRange keyRange(bool& found, QCP::SignDomain sd = QCP::sdBoth) const override
     {
-        return qcp::algo::keyRange(mKeys, found, sd);
+        return qcp::algo::keyRangeSorted(mKeys, found, sd);
     }
 
     QCPRange valueRange(int column, bool& found, QCP::SignDomain sd = QCP::sdBoth,

--- a/src/datasource/soa-multi-datasource.h
+++ b/src/datasource/soa-multi-datasource.h
@@ -50,7 +50,7 @@ public:
 
     QCPRange keyRange(bool& found, QCP::SignDomain sd = QCP::sdBoth) const override
     {
-        return qcp::algo::keyRange(mKeys, found, sd);
+        return qcp::algo::keyRangeSorted(mKeys, found, sd);
     }
 
     QCPRange valueRange(int column, bool& found, QCP::SignDomain sd = QCP::sdBoth,

--- a/src/plottables/plottable-histogram2d.cpp
+++ b/src/plottables/plottable-histogram2d.cpp
@@ -65,6 +65,7 @@ void QCPHistogram2D::installTransform()
 void QCPHistogram2D::setDataSource(std::shared_ptr<QCPAbstractDataSource> source)
 {
     mDataSource = std::move(source);
+    invalidateBoundsCache();
     mPipeline.setSource(mDataSource);
 }
 
@@ -75,7 +76,31 @@ void QCPHistogram2D::setDataSource(std::unique_ptr<QCPAbstractDataSource> source
 
 void QCPHistogram2D::dataChanged()
 {
+    invalidateBoundsCache();
     mPipeline.onDataChanged();
+}
+
+void QCPHistogram2D::invalidateBoundsCache() const
+{
+    for (auto& row : mBoundsCache)
+        for (auto& entry : row)
+            entry.valid = false;
+}
+
+bool QCPHistogram2D::cachedFiniteBounds(QCPRange& keyOut, QCPRange& valueOut,
+                                        bool keyPositiveOnly, bool valuePositiveOnly) const
+{
+    auto& entry = mBoundsCache[keyPositiveOnly ? 1 : 0][valuePositiveOnly ? 1 : 0];
+    if (!entry.valid)
+    {
+        entry.found = mDataSource
+            && mDataSource->finiteKeyValueBounds(entry.key, entry.value,
+                                                 keyPositiveOnly, valuePositiveOnly);
+        entry.valid = true;
+    }
+    keyOut = entry.key;
+    valueOut = entry.value;
+    return entry.found;
 }
 
 void QCPHistogram2D::setBins(int keyBins, int valueBins)
@@ -327,8 +352,7 @@ QCPRange QCPHistogram2D::getKeyRange(bool& foundRange, QCP::SignDomain inSignDom
     // shortcut would be wrong. Report the true finite min/max (positive-only on
     // a log axis), matching what bin2d() accumulates.
     QCPRange kr, vr;
-    foundRange = mDataSource->finiteKeyValueBounds(
-        kr, vr, inSignDomain == QCP::sdPositive, false);
+    foundRange = cachedFiniteBounds(kr, vr, inSignDomain == QCP::sdPositive, false);
     return foundRange ? kr : QCPRange();
 }
 
@@ -340,7 +364,31 @@ QCPRange QCPHistogram2D::getValueRange(bool& foundRange, QCP::SignDomain inSignD
         foundRange = false;
         return {};
     }
-    return mDataSource->valueRange(foundRange, inSignDomain, inKeyRange);
+    const bool hasKeyRestriction = inKeyRange.lower != inKeyRange.upper
+                                    || inKeyRange.lower != 0.0;
+    if (!hasKeyRestriction)
+        return mDataSource->valueRange(foundRange, inSignDomain, inKeyRange);
+
+    // Histogram keys are scattered: the source's key-restricted valueRange
+    // binary-searches sorted keys (graph contract) and would be wrong here —
+    // scan linearly through the virtual accessors instead.
+    foundRange = false;
+    double lo = std::numeric_limits<double>::max();
+    double hi = std::numeric_limits<double>::lowest();
+    const int n = mDataSource->size();
+    for (int i = 0; i < n; ++i)
+    {
+        const double k = mDataSource->keyAt(i);
+        if (k < inKeyRange.lower || k > inKeyRange.upper)
+            continue;
+        const double v = mDataSource->valueAt(i);
+        if (inSignDomain == QCP::sdPositive && v <= 0) continue;
+        if (inSignDomain == QCP::sdNegative && v >= 0) continue;
+        if (v < lo) lo = v;
+        if (v > hi) hi = v;
+        foundRange = true;
+    }
+    return foundRange ? QCPRange(lo, hi) : QCPRange();
 }
 
 double QCPHistogram2D::selectTest(const QPointF& pos, bool onlySelectable, QVariant*) const
@@ -355,7 +403,7 @@ double QCPHistogram2D::selectTest(const QPointF& pos, bool onlySelectable, QVari
 
     // Use the true scattered min/max, not the sorted first/last shortcut.
     QCPRange kr, vr;
-    if (mDataSource->finiteKeyValueBounds(kr, vr) && kr.contains(key) && vr.contains(value))
+    if (cachedFiniteBounds(kr, vr, false, false) && kr.contains(key) && vr.contains(value))
         return 0;
     return -1;
 }

--- a/src/plottables/plottable-histogram2d.h
+++ b/src/plottables/plottable-histogram2d.h
@@ -112,5 +112,21 @@ private:
     QCPHistogramPipeline mPipeline;
     QCPColormapRenderer mRenderer;
 
+    // finiteKeyValueBounds is an O(N) scan over the raw scatter; selectTest
+    // calls it per mouse event and getKeyRange per rescale. The bounds only
+    // change with the data — memoize per (keyPositiveOnly, valuePositiveOnly),
+    // invalidated by setDataSource/dataChanged.
+    struct BoundsCache
+    {
+        bool valid = false;
+        bool found = false;
+        QCPRange key;
+        QCPRange value;
+    };
+    mutable BoundsCache mBoundsCache[2][2];
+    void invalidateBoundsCache() const;
+    bool cachedFiniteBounds(QCPRange& keyOut, QCPRange& valueOut,
+                            bool keyPositiveOnly, bool valuePositiveOnly) const;
+
     void installTransform();
 };

--- a/tests/auto/test-datasource/test-datasource.cpp
+++ b/tests/auto/test-datasource/test-datasource.cpp
@@ -111,6 +111,63 @@ void TestDataSource::algoValueRange()
     QCOMPARE(range.upper, 8.0);
 }
 
+void TestDataSource::algoValueRangeRestrictionMatchesBruteForce()
+{
+    // Equivalence guard for the windowed (binary-search) key restriction:
+    // results must match a brute-force linear scan for every window placement,
+    // including boundary-exact keys and windows outside the data.
+    std::vector<double> keys, values;
+    for (int i = 0; i < 1000; ++i)
+    {
+        keys.push_back(i * 0.5);
+        values.push_back(std::sin(i * 0.37) * 50.0);
+    }
+
+    auto brute = [&](QCP::SignDomain sd, const QCPRange& kr, bool& found) {
+        found = false;
+        double lo = std::numeric_limits<double>::max();
+        double hi = std::numeric_limits<double>::lowest();
+        for (size_t i = 0; i < keys.size(); ++i)
+        {
+            if (keys[i] < kr.lower || keys[i] > kr.upper)
+                continue;
+            double v = values[i];
+            if (sd == QCP::sdPositive && v <= 0) continue;
+            if (sd == QCP::sdNegative && v >= 0) continue;
+            if (v < lo) lo = v;
+            if (v > hi) hi = v;
+            found = true;
+        }
+        return found ? QCPRange(lo, hi) : QCPRange();
+    };
+
+    const QCPRange windows[] = {
+        {100.0, 200.0},   // boundary-exact keys on both ends
+        {100.25, 200.75}, // boundaries between keys
+        {0.0, 499.5},     // full range
+        {-50.0, -10.0},   // entirely before the data
+        {600.0, 700.0},   // entirely after the data
+        {499.5, 499.5},   // degenerate window on the last key
+    };
+    const QCP::SignDomain domains[] = {QCP::sdBoth, QCP::sdPositive, QCP::sdNegative};
+
+    for (const auto& w : windows)
+    {
+        for (auto sd : domains)
+        {
+            bool foundRef = false, foundGot = false;
+            QCPRange ref = brute(sd, w, foundRef);
+            QCPRange got = qcp::algo::valueRange(keys, values, foundGot, sd, w);
+            QCOMPARE(foundGot, foundRef);
+            if (foundRef)
+            {
+                QCOMPARE(got.lower, ref.lower);
+                QCOMPARE(got.upper, ref.upper);
+            }
+        }
+    }
+}
+
 void TestDataSource::algoLinesToPixels()
 {
     // Tested in integration with QCPGraph2 (needs axis objects)

--- a/tests/auto/test-datasource/test-datasource.h
+++ b/tests/auto/test-datasource/test-datasource.h
@@ -15,6 +15,7 @@ private slots:
     void algoFindEnd();
     void algoKeyRange();
     void algoValueRange();
+    void algoValueRangeRestrictionMatchesBruteForce();
     void algoLinesToPixels();
     void algoOptimizedLineData();
 

--- a/tests/auto/test-multi-datasource/test-multi-datasource.cpp
+++ b/tests/auto/test-multi-datasource/test-multi-datasource.cpp
@@ -216,6 +216,42 @@ void TestMultiDataSource::linesToPixelsNanProducesNanNotZero()
     QVERIFY(qIsNaN(lines[3].x()) || qIsNaN(lines[3].y()));
 }
 
+void TestMultiDataSource::adaptiveSamplingInteriorNaNNoSpuriousBreaks()
+{
+    // The interval's closing point used to be derived as
+    // intervalFirst + intervalCount - 1, but NaN samples are skipped WITHOUT
+    // counting — with interior NaNs that index can land on a NaN, injecting a
+    // spurious (NaN, NaN) line break (phantom gap) into gap-free data.
+    constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+
+    const int N = 10000; // ~25 points/pixel on 400 px -> adaptive path
+    std::vector<double> keys(N);
+    std::vector<double> vals(N);
+    for (int i = 0; i < N; ++i)
+    {
+        keys[i] = static_cast<double>(i); // uniform: no key gaps at all
+        // every other sample NaN: the naive closing index hits NaN constantly
+        vals[i] = (i % 2 == 1) ? NaN : std::sin(i * 0.01);
+    }
+    std::vector<std::vector<double>> cols = {std::move(vals)};
+    QCPSoAMultiDataSource src(std::move(keys), std::move(cols));
+
+    mPlot->xAxis->setRange(0, N);
+    mPlot->yAxis->setRange(-1.5, 1.5);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    auto result = src.getOptimizedLineData(0, 0, N, 400, mPlot->xAxis, mPlot->yAxis);
+    QVERIFY(result.size() > 0);
+
+    // Keys have no gaps and adaptive sampling skips NaN values silently:
+    // the output must not contain any NaN break point.
+    int nanCount = 0;
+    for (const auto& pt : result)
+        if (qIsNaN(pt.x()) || qIsNaN(pt.y()))
+            ++nanCount;
+    QCOMPARE(nanCount, 0);
+}
+
 void TestMultiDataSource::adaptiveSamplingNanDoesNotPoisonMinMax()
 {
     // Reproducer: if the first value in a pixel interval was NaN, minValue/maxValue

--- a/tests/auto/test-multi-datasource/test-multi-datasource.h
+++ b/tests/auto/test-multi-datasource/test-multi-datasource.h
@@ -27,6 +27,7 @@ private slots:
     // NaN gap handling
     void linesToPixelsNanProducesNanNotZero();
     void adaptiveSamplingNanDoesNotPoisonMinMax();
+    void adaptiveSamplingInteriorNaNNoSpuriousBreaks();
 
     // Key-space gap detection
     void linesToPixelsBreaksAtKeyGaps();

--- a/tests/auto/test-pipeline/test-pipeline.cpp
+++ b/tests/auto/test-pipeline/test-pipeline.cpp
@@ -1381,6 +1381,45 @@ void TestPipeline::histogram2dKeyRangeUnsorted()
     QCOMPARE(kr.upper, 9.0);
 }
 
+void TestPipeline::histogram2dValueRangeRestrictedUnsortedKeys()
+{
+    // Histogram keys are scattered: a key-restricted value range must NOT use
+    // the sorted-keys binary-search window (that's only valid for graphs).
+    auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);
+    std::vector<double> keys = {5.0, 1.0, 9.0, 2.0, 7.0};
+    std::vector<double> vals = {50.0, 10.0, 90.0, 20.0, 70.0};
+    hist->setData(std::move(keys), std::move(vals));
+
+    bool found = false;
+    QCPRange vr = hist->getValueRange(found, QCP::sdBoth, QCPRange(1.5, 6.0));
+    QVERIFY(found);
+    QCOMPARE(vr.lower, 20.0); // keys 5.0 and 2.0 are inside [1.5, 6.0]
+    QCOMPARE(vr.upper, 50.0);
+}
+
+void TestPipeline::histogram2dSelectTestReflectsNewData()
+{
+    // Bounds used by selectTest are memoized per data generation: a data
+    // change must invalidate the cache, not keep answering for the old data.
+    mPlot->xAxis->setRange(0, 100);
+    mPlot->yAxis->setRange(0, 100);
+    mPlot->replot(QCustomPlot::rpImmediateRefresh);
+
+    auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);
+    hist->setData(std::vector<double>{10.0, 20.0}, std::vector<double>{10.0, 20.0});
+
+    const QPointF inside_old(mPlot->xAxis->coordToPixel(15.0),
+                             mPlot->yAxis->coordToPixel(15.0));
+    QVERIFY(hist->selectTest(inside_old, false) >= 0);
+    QVERIFY(hist->selectTest(inside_old, false) >= 0); // cached round
+
+    hist->setData(std::vector<double>{60.0, 80.0}, std::vector<double>{60.0, 80.0});
+    const QPointF inside_new(mPlot->xAxis->coordToPixel(70.0),
+                             mPlot->yAxis->coordToPixel(70.0));
+    QVERIFY(hist->selectTest(inside_old, false) < 0);  // stale cache would say yes
+    QVERIFY(hist->selectTest(inside_new, false) >= 0);
+}
+
 void TestPipeline::histogram2dPipelineBins()
 {
     auto* hist = new QCPHistogram2D(mPlot->xAxis, mPlot->yAxis);

--- a/tests/auto/test-pipeline/test-pipeline.h
+++ b/tests/auto/test-pipeline/test-pipeline.h
@@ -95,6 +95,8 @@ private slots:
 
     // QCPHistogram2D
     void histogram2dKeyRangeUnsorted();
+    void histogram2dValueRangeRestrictedUnsortedKeys();
+    void histogram2dSelectTestReflectsNewData();
     void histogram2dPipelineBins();
     void histogram2dNormalizationColumn();
     void histogram2dNormalizationToggleNoRebind();


### PR DESCRIPTION
> **Stacked on #34** (← #33 ← #32) — merge those first; this PR's diff then collapses to its own commit (`575f666`).

- **`optimizedLineData` derived an interval's closing point as `intervalFirst + intervalCount - 1`**, but NaN samples are skipped WITHOUT counting: with interior NaNs that index lands on a NaN, injecting a spurious (NaN, NaN) line break — phantom gaps in dense gappy data (the norm in space physics). The interval now tracks the index of the last accepted sample explicitly.

- **The multi-column variant had two related NaN holes**: an interval reset landing on a NaN sample seeded minVal/maxVal with NaN, poisoning `std::min`/`std::max` for the rest of the interval (envelope silently dropped); and a single-sample NaN interval appended an explicit break point where the adaptive contract (matching the single-column variant) is to skip NaN values — key gaps are detected separately.

  Reproducer: `adaptiveSamplingInteriorNaNNoSpuriousBreaks` (gap-free keys, every other value NaN → output contained NaN break points before).

- **`buildL1Cache` reused an existing L1 when only `sourceSize` matched**; the previously dead `cachedKeyRange` member now participates in the validity check (`keyRange` is O(1) on sorted sources), so replacing the data with an equally-sized batch can never reuse a stale binning.

Part of the 2026-06-09 audit (H4/M7). Last of the stack: #32 → #33 → #34 → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)